### PR TITLE
Fix kallistobus didn't run with multiple samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Pipeline ported to dsl2
 * Template update with latest nf-core/tools v2.1
 
+### Fixes
+
+* Make sure Kallisto/BUStools runs on multiple samples [#77](https://github.com/nf-core/scrnaseq/pull/77)
+
 ## v1.1.0 - 2021-03-24 "Olive Mercury Corgi"
 
 * Template update with latest nf-core/tools v1.13.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-* Make sure Kallisto/BUStools runs on multiple samples [#77](https://github.com/nf-core/scrnaseq/pull/77)
+* Make sure pipeline runs on multiple samples [#77](https://github.com/nf-core/scrnaseq/pull/77)
 
 ## v1.1.0 - 2021-03-24 "Olive Mercury Corgi"
 

--- a/workflows/alevin.nf
+++ b/workflows/alevin.nf
@@ -173,7 +173,13 @@ workflow SCRNASEQ_ALEVIN {
     /*
     * Perform quantification with salmon alevin
     */
-    SALMON_ALEVIN ( ch_fastq, salmon_index_alevin, ch_txp2gene, protocol, ch_barcode_whitelist )
+    SALMON_ALEVIN (
+        ch_fastq,
+        salmon_index_alevin.collect(),
+        ch_txp2gene.collect(),
+        protocol,
+        ch_barcode_whitelist.collect()
+    )
     ch_software_versions = ch_software_versions.mix(SALMON_ALEVIN.out.version.first().ifEmpty(null))
     ch_salmon_multiqc = SALMON_ALEVIN.out.alevin_results
 

--- a/workflows/kallisto_bustools.nf
+++ b/workflows/kallisto_bustools.nf
@@ -137,8 +137,8 @@ workflow KALLISTO_BUSTOOLS {
     */
     KALLISTOBUSTOOLS_COUNT(
         ch_fastq,
-        ch_kallisto_index,
-        ch_kallisto_gene_map,
+        ch_kallisto_index.collect(),
+        ch_kallisto_gene_map.collect(),
         [],
         [],
         false,

--- a/workflows/starsolo.nf
+++ b/workflows/starsolo.nf
@@ -148,9 +148,9 @@ workflow STARSOLO {
     */
     STAR_ALIGN(
         ch_fastq,
-        star_index,
-        gtf,
-        ch_barcode_whitelist,
+        star_index.collect(),
+        gtf.collect(),
+        ch_barcode_whitelist.collect(),
         protocol
     )
     ch_software_versions = ch_software_versions.mix(STAR_ALIGN.out.version.first().ifEmpty(null))


### PR DESCRIPTION
<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

Du to a lacking `collect()` on the index, kallisto only ran on a single sample even when multiple ones were specified in the samplesheet. 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - add to the software_versions process and a regex to `scrape_software_versions.py`
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
