### PR TITLE
add default to outdir as it was in schema

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
     // generic options
     aligner           = 'alevin'
     bustools_correct  = true
-    outdir            = null
+    outdir            = './results'
     input             = null
     save_reference    = null
     protocol          = '10XV3'

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ params {
     // generic options
     aligner           = 'alevin'
     bustools_correct  = true
-    outdir            = './results'
+    outdir            = null
     input             = null
     save_reference    = null
     protocol          = '10XV3'

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -22,8 +22,7 @@
                     "type": "string",
                     "format": "directory-path",
                     "description": "The output directory where the results will be saved. You have to use absolute paths to storage on Cloud infrastructure.",
-                    "fa_icon": "fas fa-folder-open",
-                    "default": "./results"
+                    "fa_icon": "fas fa-folder-open"
                 },
                 "email": {
                     "type": "string",


### PR DESCRIPTION
`params.outdir` had a default in schema but not in `nextflow.config`, thus was raising error when user did not specify it.