### PR TITLE
Make STAR work with compressed fastq files

### DIFF
--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -49,6 +49,7 @@ process STAR_ALIGN {
         --runThreadN $task.cpus \\
         --outFileNamePrefix $prefix. \\
         --soloCBwhitelist <(gzip -cdf $whitelist) \\
+        --readFilesCommand gzip -cdf \\
         --soloType $protocol \\
         $out_sam_type \\
         $ignore_gtf \\


### PR DESCRIPTION
See also https://github.com/nf-core/modules/issues/1688 for a request to change this in the modules repository. 

We currently use a local version of the star module - this is a quick fix until we switch to the central modules in a next iteration. 