### PR TITLE
fix: STAR mtx conversion when using GeneFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Fixed Kallistobustools workflow [#123](https://github.com/nf-core/scrnaseq/issues/123) by upgrading to nf-core/modules module
+- Fixed matrix conversion error when running STAR with --soloFeatures GeneFull [#135](https://github.com/nf-core/scrnaseq/pull/135)
 
 ## v2.0.0 - 2022-06-17 "Gray Nickel Beagle"
 

--- a/modules/local/mtx_to_h5ad.nf
+++ b/modules/local/mtx_to_h5ad.nf
@@ -26,9 +26,9 @@ process MTX_TO_H5AD {
         barcodes_tsv = "*_alevin_results/alevin/quants_mat_rows.txt"
         features_tsv = "*_alevin_results/alevin/quants_mat_cols.txt"
     } else if (params.aligner == 'star') {
-        mtx_matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx"
-        barcodes_tsv = "*.Solo.out/Gene*/filtered/barcodes.tsv"
-        features_tsv = "*.Solo.out/Gene*/filtered/features.tsv"
+        mtx_matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx.gz"
+        barcodes_tsv = "*.Solo.out/Gene*/filtered/barcodes.tsv.gz"
+        features_tsv = "*.Solo.out/Gene*/filtered/features.tsv.gz"
     }
 
     //

--- a/modules/local/mtx_to_h5ad.nf
+++ b/modules/local/mtx_to_h5ad.nf
@@ -26,9 +26,9 @@ process MTX_TO_H5AD {
         barcodes_tsv = "*_alevin_results/alevin/quants_mat_rows.txt"
         features_tsv = "*_alevin_results/alevin/quants_mat_cols.txt"
     } else if (params.aligner == 'star') {
-        mtx_matrix   = "*.Solo.out/Gene/filtered/matrix.mtx"
-        barcodes_tsv = "*.Solo.out/Gene/filtered/barcodes.tsv"
-        features_tsv = "*.Solo.out/Gene/filtered/features.tsv"
+        mtx_matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx"
+        barcodes_tsv = "*.Solo.out/Gene*/filtered/barcodes.tsv"
+        features_tsv = "*.Solo.out/Gene*/filtered/features.tsv"
     }
 
     //

--- a/modules/local/mtx_to_seurat.nf
+++ b/modules/local/mtx_to_seurat.nf
@@ -30,9 +30,9 @@ process MTX_TO_SEURAT {
         barcodes = "*_alevin_results/alevin/quants_mat_rows.txt"
         features = "*_alevin_results/alevin/quants_mat_cols.txt"
     } else if (params.aligner == 'star') {
-        matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx"
-        barcodes = "*.Solo.out/Gene*/filtered/barcodes.tsv"
-        features = "*.Solo.out/Gene*/filtered/features.tsv"
+        matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx.gz"
+        barcodes = "*.Solo.out/Gene*/filtered/barcodes.tsv.gz"
+        features = "*.Solo.out/Gene*/filtered/features.tsv.gz"
     }
 
     """

--- a/modules/local/mtx_to_seurat.nf
+++ b/modules/local/mtx_to_seurat.nf
@@ -30,9 +30,9 @@ process MTX_TO_SEURAT {
         barcodes = "*_alevin_results/alevin/quants_mat_rows.txt"
         features = "*_alevin_results/alevin/quants_mat_cols.txt"
     } else if (params.aligner == 'star') {
-        matrix   = "*.Solo.out/Gene/filtered/matrix.mtx"
-        barcodes = "*.Solo.out/Gene/filtered/barcodes.tsv"
-        features = "*.Solo.out/Gene/filtered/features.tsv"
+        matrix   = "*.Solo.out/Gene*/filtered/matrix.mtx"
+        barcodes = "*.Solo.out/Gene*/filtered/barcodes.tsv"
+        features = "*.Solo.out/Gene*/filtered/features.tsv"
     }
 
     """

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -69,6 +69,11 @@ process STAR_ALIGN {
         gzip ${prefix}.unmapped_2.fastq
     fi
 
+    if [ -d ${prefix}.Solo.out ]; then
+        # Backslashes still need to be escaped (https://github.com/nextflow-io/nextflow/issues/67)
+        find ${prefix}.Solo.out \\( -name "*.tsv" -o -name "*.mtx" \\) -exec gzip {} \\;
+    fi
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         star: \$(STAR --version | sed -e "s/STAR_//g")


### PR DESCRIPTION
When STAR is run  with the flag `--soloFeatures GeneFull` (permits
counting of exonic and intronic reads), the output is stored in
`*.Solo.out/GeneFull/` and not `*.Solo.out/Gene`. As a result, matrix
conversion results in an error, as matrix, barcodes and features cannot
be found. This error can be fixed by adding an asterisk in the file
path provided to the mtx conversion modules.

Additionally added compression of starsolo outputs, both for storage
purposes and for downstream compatibility with nf-core/scflow (which 
requires gzipped outputs similar to cellranger).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
