### PR TITLE
fix(mtx_to_seurat): could not find ReadMtx using conda profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed Kallistobustools workflow [#123](https://github.com/nf-core/scrnaseq/issues/123) by upgrading to nf-core/modules module
 - Fixed matrix conversion error when running STAR with --soloFeatures GeneFull [#135](https://github.com/nf-core/scrnaseq/pull/135)
+- Fixed seurat matrix conversion error when running with conda profile [#136](https://github.com/nf-core/scrnaseq/pull/136)
 
 ## v2.0.0 - 2022-06-17 "Gray Nickel Beagle"
 

--- a/modules/local/mtx_to_seurat.nf
+++ b/modules/local/mtx_to_seurat.nf
@@ -2,7 +2,7 @@ process MTX_TO_SEURAT {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "seurat-scripts" : null)
+    conda (params.enable_conda ? "r-seurat" : null)
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'docker://satijalab/seurat:4.1.0' :
         'satijalab/seurat:4.1.0' }"


### PR DESCRIPTION
The conda package, `seurat-scripts`, does not contain the function,
`ReadMtx()`. Thus, running the test and conda profile resulting in
the error, `"Error in ReadMtx(mtx = mtx_file, features = feature_file,
 cells = barcode_file,  : could not find function "ReadMtx"`. This
can be resolved by using the conda package, [`r-seurat`](https://anaconda.org/conda-forge/r-seurat).

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
