### PR TITLE
Add genomic feature and barcode length option for STAR

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -70,7 +70,7 @@ if (params.aligner == "alevin") {
 if (params.aligner == "star") {
     process {
         withName: STAR_ALIGN {
-            ext.args = "--readFilesCommand zcat --runDirPerm All_RWX --outWigType bedGraph --twopassMode Basic --outSAMtype BAM SortedByCoordinate"
+            ext.args = "--readFilesCommand zcat --runDirPerm All_RWX --outWigType bedGraph --twopassMode Basic --outSAMtype BAM SortedByCoordinate --clipAdapterType CellRanger4 --outFilterScoreMin 30 --soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR --soloUMIdedup 1MM_CR"
         }
     }
 }

--- a/modules/local/star_align.nf
+++ b/modules/local/star_align.nf
@@ -18,6 +18,8 @@ process STAR_ALIGN {
     path whitelist
     val protocol
     val other_10x_parameters
+    val barcode_length
+    val star_genomic_features
 
     output:
     tuple val(meta), path('*d.out.bam')       , emit: bam
@@ -51,6 +53,8 @@ process STAR_ALIGN {
         --outFileNamePrefix $prefix. \\
         --soloCBwhitelist <(gzip -cdf $whitelist) \\
         --soloType $protocol \\
+        --soloBarcodeReadLength $barcode_length \\
+        --soloFeatures $star_genomic_features \\
         $other_10x_parameters \\
         $out_sam_type \\
         $ignore_gtf \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,8 @@ params {
     // STARsolo parameters
     star_index          = null
     star_ignore_sjdbgtf = null
+    barcode_length        = null
+    star_genomic_features = 'Gene'
 
     // Cellranger parameters
     cellranger_index    = null

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,7 +36,7 @@ params {
     // STARsolo parameters
     star_index          = null
     star_ignore_sjdbgtf = null
-    barcode_length        = null
+    barcode_length        = 26
     star_genomic_features = 'Gene'
 
     // Cellranger parameters

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -154,6 +154,17 @@
                 "star_ignore_sjdbgtf": {
                     "type": "string",
                     "description": "Ignore the SJDB GTF file."
+                },
+                "barcode_length": {
+                    "type": "integer",
+                    "description": "Customize barcode read length."
+                },
+                "star_genomic_features": {
+                    "type": "string",
+                    "description": "Genomic features for which UMI counts per cell barcode are collected, e.g. Gene (default).",
+                    "default": "Gene",
+                    "help_text": "To choose which one to use, please specify either `Gene` or `GeneFull` as a parameter option. By `Gene`, counting reads match gene transcript; by `GeneFull`, counting all reads overlap exons and introns.",
+                    "enum": ["Gene", "GeneFull"]
                 }
             },
             "fa_icon": "fas fa-star"

--- a/subworkflows/local/starsolo.nf
+++ b/subworkflows/local/starsolo.nf
@@ -17,6 +17,8 @@ workflow STARSOLO {
     barcode_whitelist
     ch_fastq
     other_10x_parameters
+    barcode_length
+    star_genomic_features
 
     main:
     ch_versions = Channel.empty()
@@ -44,7 +46,9 @@ workflow STARSOLO {
         gtf,
         barcode_whitelist,
         protocol,
-        other_10x_parameters
+        other_10x_parameters,
+        barcode_length,
+        star_genomic_features
     )
     ch_versions = ch_versions.mix(STAR_ALIGN.out.versions)
 

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -91,6 +91,8 @@ ch_salmon_index = params.salmon_index ? file(params.salmon_index) : []
 
 //star params
 ch_star_index = params.star_index ? file(params.star_index) : []
+barcode_length = params.barcode_length
+star_genomic_features = params.star_genomic_features
 
 //cellranger params
 ch_cellranger_index = params.cellranger_index ? file(params.cellranger_index) : []
@@ -146,7 +148,9 @@ workflow SCRNASEQ {
             protocol,
             ch_barcode_whitelist,
             ch_fastq,
-            other_parameters
+            other_parameters,
+            barcode_length,
+            star_genomic_features
         )
         ch_versions = ch_versions.mix(STARSOLO.out.ch_versions)
         ch_multiqc_star = STARSOLO.out.for_multiqc


### PR DESCRIPTION
<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

(1) Current `--aligner star` does not include`--soloBarcodeReadLength` in the executed command and it leads to `FATAL ERROR` once the barcode length is not equal to default value 26. This can be resolved with additional parameter to parse customized length in. 
(2) `--include-introns` is now set by default on CellRanger v7.0 and thus it could be useful to have `--soloFeatures` as a new star option to align the output from CellRanger.
(3) According to `STARsolo.md`, it is recommended to have: `--clipAdapterType CellRanger4 --outFilterScoreMin 30
--soloCBmatchWLtype 1MM_multi_Nbase_pseudocounts --soloUMIfiltering MultiGeneUMI_CR --soloUMIdedup 1MM_CR` for the best match to CellRanger >= 4.0. (https://github.com/alexdobin/STAR/blob/master/docs/STARsolo.md)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
