### PR TITLE
fix txp2gene retrieval bug when salmon_index is supplied

### DIFF
--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -27,15 +27,9 @@ workflow SCRNASEQ_ALEVIN {
     main:
     ch_versions = Channel.empty()
 
-    assert salmon_index || (genome_fasta && gtf) || (genome_fasta && transcript_fasta):
+    assert (salmon_index && txp2gene) || (genome_fasta && gtf) || (genome_fasta && transcript_fasta && txp2gene):
         """Must provide a genome fasta file ('--fasta') and a gtf file ('--gtf'), or a genome fasta file
-        and a transcriptome fasta file ('--transcript_fasta`) if no index is given!""".stripIndent()
-
-    if (transcript_fasta || salmon_index) {
-        assert txp2gene:
-            "Since either a built transcript or a built salmon index was provided ('--transcript_fasta' or '--salmon_index'), user must also provide a simpleaf gene map ('--txp2gene') to use with simpleaf quant!"
-    }
-
+        and a transcriptome fasta file ('--transcript_fasta`) if no index and txp2gene is given!""".stripIndent()
 
     /*
     * Build salmon index

--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -27,7 +27,9 @@ workflow SCRNASEQ_ALEVIN {
     main:
     ch_versions = Channel.empty()
 
-    assert (salmon_index && txp2gene) || (genome_fasta && gtf) || (genome_fasta && transcript_fasta && txp2gene):
+    assert (genome_fasta && gtf && salmon_index && txp2gene) \
+           || (genome_fasta && gtf) \ 
+           || (genome_fasta && gtf && transcript_fasta && txp2gene):
         """Must provide a genome fasta file ('--fasta') and a gtf file ('--gtf'), or a genome fasta file
         and a transcriptome fasta file ('--transcript_fasta`) if no index and txp2gene is given!""".stripIndent()
 

--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -33,7 +33,7 @@ workflow SCRNASEQ_ALEVIN {
 
     if (transcript_fasta || salmon_index) {
         assert txp2gene:
-            "Since a built transcript was provided ('--transcript_fasta'), must also provide a simpleaf gene map ('--txp2gene') to use with simpleaf quant!"
+            "Since either a built transcript or a built salmon index was provided ('--transcript_fasta' or '--salmon_index'), user must also provide a simpleaf gene map ('--txp2gene') to use with simpleaf quant!"
     }
 
 

--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -31,7 +31,7 @@ workflow SCRNASEQ_ALEVIN {
         """Must provide a genome fasta file ('--fasta') and a gtf file ('--gtf'), or a genome fasta file
         and a transcriptome fasta file ('--transcript_fasta`) if no index is given!""".stripIndent()
 
-    if (transcript_fasta) {
+    if (transcript_fasta || salmon_index) {
         assert txp2gene:
             "Since a built transcript was provided ('--transcript_fasta'), must also provide a simpleaf gene map ('--txp2gene') to use with simpleaf quant!"
     }
@@ -45,12 +45,13 @@ workflow SCRNASEQ_ALEVIN {
         salmon_index = SIMPLEAF_INDEX.out.index.collect()
         transcript_tsv = SIMPLEAF_INDEX.out.transcript_tsv.collect()
         ch_versions = ch_versions.mix(SIMPLEAF_INDEX.out.versions)
+
+        if (!txp2gene) { 
+            txp2gene = SIMPLEAF_INDEX.out.transcript_tsv 
+        }
     }
 
-    /*
-    * Select txp2gene map
-    */
-    if (!txp2gene) { txp2gene = SIMPLEAF_INDEX.out.transcript_tsv }
+
 
     /*
     * Perform quantification with salmon alevin

--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -27,9 +27,7 @@ workflow SCRNASEQ_ALEVIN {
     main:
     ch_versions = Channel.empty()
 
-    assert (genome_fasta && gtf && salmon_index && txp2gene) \
-           || (genome_fasta && gtf) \ 
-           || (genome_fasta && gtf && transcript_fasta && txp2gene):
+    assert (genome_fasta && gtf && salmon_index && txp2gene) || (genome_fasta && gtf)  || (genome_fasta && gtf && transcript_fasta && txp2gene):
         """Must provide a genome fasta file ('--fasta') and a gtf file ('--gtf'), or a genome fasta file
         and a transcriptome fasta file ('--transcript_fasta`) if no index and txp2gene is given!""".stripIndent()
 


### PR DESCRIPTION
txp2gene is generated as part of the salmon indexing, but if an index is supplied, the file must be supplied manually

<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
