### PR TITLE
Ensure that starsolo outputs channel that matches others, including meta map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v2.3.0dev
-
 - Fix problem on samplesheet check related to amount of columns ([[#211](https://github.com/nf-core/scrnaseq/issues/211)])
+- Fixed bug in starsolo output cardinality.
 
 ## v2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## v2.3.0dev
+
 - Fix problem on samplesheet check related to amount of columns ([[#211](https://github.com/nf-core/scrnaseq/issues/211)])
 - Fixed bug in starsolo output cardinality.
 

--- a/subworkflows/local/starsolo.nf
+++ b/subworkflows/local/starsolo.nf
@@ -56,7 +56,5 @@ workflow STARSOLO {
     star_index  = star_index
     star_result = STAR_ALIGN.out.tab
     star_counts = STAR_ALIGN.out.counts
-    for_multiqc = STAR_ALIGN.out.log_final.collect{it[1]}.ifEmpty([])
-
-
+    for_multiqc = STAR_ALIGN.out.log_final
 }

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -236,8 +236,8 @@ workflow SCRNASEQ {
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
     ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_fastqc.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_alevin.collect{it[1]}.ifEmpty([])),
-    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_star.collect{it[1]}.ifEmpty([])),
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_alevin.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_star.collect{it[1]}.ifEmpty([]))
 
     MULTIQC (
         ch_multiqc_files.collect(),


### PR DESCRIPTION
 # Overview

Before this PR, the STARSOLO local subworkflow emits the `for_multiqc` channel and in doing so trims out the `meta` map by returning just the path with `.collect{it[1]}`:

```groovy
    emit:
    // snip
    for_multiqc = STAR_ALIGN.out.log_final.collect{it[1]}.ifEmpty([])
```

This `for_multiqc` output is then assigned to `ch_multiqc_star`:

```groovy
ch_multiqc_star = STARSOLO.out.for_multiqc
```

and then imported into multiqc, but in doing so assumes that the meta map is still included, and re-trims it:

```groovy
ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_star.collect{it[1]}.ifEmpty([]))
```

Performing two rounds of `.collect{it[1]}` returns a `null` object, which throws an error when MultiQC is queued.

# The Fix

I removed the first meta map removal in the STARSOLO subworkflow.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
