### PR TITLE
Remove globs from ecr profile

### DIFF
--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -12,25 +12,25 @@ docker.registry = 'public.ecr.aws'
 podman.registry = 'public.ecr.aws'
 
 process {
-    withName: '.*:CONCAT_H5AD' {
+    withName: 'CONCAT_H5AD' {
         container = 'quay.io/biocontainers/scanpy:1.7.2--pyhdfd78af_0'
     }
-    withName: '.*:GENE_MAP' {
+    withName: 'GENE_MAP' {
         container = 'quay.io/biocontainers/python:3.8.3'
     }
-    withName: '.*:GTF_GENE_FILTER' {
+    withName: 'GTF_GENE_FILTER' {
         container = 'quay.io/biocontainers/python:3.9--1'
     }
-    withName: '.*:GUNZIP' {
+    withName: 'GUNZIP' {
         container = 'quay.io/nf-core/ubuntu:20.04'
     }
-    withName: '.*:MTX_TO_H5AD' {
+    withName: 'MTX_TO_H5AD' {
         container = 'quay.io/biocontainers/scanpy:1.7.2--pyhdfd78af_0'
     }
-    withName: '.*:SAMPLESHEET_CHECK' {
+    withName: 'SAMPLESHEET_CHECK' {
         container = 'quay.io/biocontainers/python:3.8.3'
     }
-    withName: '.*:STAR_GENOMEGENERATE' {
+    withName: 'STAR_GENOMEGENERATE' {
         container = 'quay.io/biocontainers/mulled-v2-1fa26d1ce03c295fe2fdcf85831a92fbcbd7e8c2:1df389393721fc66f3fd8778ad938ac711951107-0'
     }
 }


### PR DESCRIPTION
Removes globs from ECR profile which means they will be correctly found if using an alias. i.e.,:

```
include { TOOL as SUBTOOL } from file.nf
```

will match:
```
withName: TOOL 
```

or 
```
withName: .*SUBTOOL
```

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
