### PR TITLE
Fix_file_collision_when_using_cellranger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+- Fixed issue with file collisions while using cellranger
+
 ## v2.3.1 - 2023-06-02 Yellow Strontium Pinscher
 
 - Add `public_aws_ecr` config for using the AWS mirror of containers where possible ([#225](https://github.com/nf-core/scrnaseq/pull/225))

--- a/modules/local/mtx_to_seurat.nf
+++ b/modules/local/mtx_to_seurat.nf
@@ -20,9 +20,9 @@ process MTX_TO_SEURAT {
     script:
     def aligner = params.aligner
     if (params.aligner == "cellranger") {
-        matrix   = "filtered_feature_bc_matrix/matrix.mtx.gz"
-        barcodes = "filtered_feature_bc_matrix/barcodes.tsv.gz"
-        features = "filtered_feature_bc_matrix/features.tsv.gz"
+        matrix   = "matrix.mtx.gz"
+        barcodes = "barcodes.tsv.gz"
+        features = "features.tsv.gz"
     } else if (params.aligner == "kallisto") {
         matrix   = "*count/counts_unfiltered/*.mtx"
         barcodes = "*count/counts_unfiltered/*.barcodes.txt"

--- a/subworkflows/local/mtx_conversion.nf
+++ b/subworkflows/local/mtx_conversion.nf
@@ -14,6 +14,14 @@ workflow MTX_CONVERSION {
     main:
         ch_versions = Channel.empty()
 
+        // Cellranger module output contains too many files which cause path collisions, we filter to the ones we need.
+        if ( params.aligner == "cellranger" ) {
+            mtx_matrices = mtx_matrices.map { meta, mtx_files ->
+                    [ meta, mtx_files.findAll { it.toString().contains("filtered_feature_bc_matrix") } ]
+                }
+                .filter { meta, mtx_files -> mtx_files } // Remove any that are missing the relevant files
+        }
+
         //
         // Convert matrix to h5ad
         //


### PR DESCRIPTION
- When using cellranger, files would collide because they had the same filename. This fix filters to only the relevant files when creating seurat or h5ad files.
- As a bonus, it should offer a small speed improvement.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
