### PR TITLE
Add singularity.registry = 'quay.io' and bump NF version to 23.04.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -42,7 +42,7 @@ body:
     attributes:
       label: System information
       description: |
-        * Nextflow version _(eg. 22.10.1)_
+        * Nextflow version _(eg. 23.04.0)_
         * Hardware _(eg. HPC, Desktop, Cloud)_
         * Executor _(eg. slurm, local, awsbatch)_
         * Container engine: _(e.g. Docker, Singularity, Conda, Podman, Shifter, Charliecloud, or Apptainer)_

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         NXF_VER:
-          - "22.10.1"
+          - "23.04.0"
           - "latest-everything"
         profile:
           [

--- a/.nf-core.yml
+++ b/.nf-core.yml
@@ -1,3 +1,5 @@
 repository_type: pipeline
 lint:
   template_strings: False
+  files_unchanged:
+    - .github/ISSUE_TEMPLATE/bug_report.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unpublished Version / DEV]
+
+- [#237](https://github.com/nf-core/scrnaseq/pull/237) Add `singularity.registry = 'quay.io'` and bump NF version to 23.04.0
+
 ## v2.3.2 - 2023-06-07 Patched Yellow Strontium Pinscher
 
 - Move containers for pipeline to quay.io ([#233](https://github.com/nf-core/scrnaseq/pull/233))

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![GitHub Actions Linting Status](https://github.com/nf-core/scrnaseq/workflows/nf-core%20linting/badge.svg)](https://github.com/nf-core/scrnaseq/actions?query=workflow%3A%22nf-core+linting%22)
 [![AWS CI](https://img.shields.io/badge/CI%20tests-full%20size-FF9900?logo=Amazon%20AWS)](https://nf-co.re/scrnaseq/results)
 [![Cite with Zenodo](http://img.shields.io/badge/DOI-10.5281/zenodo.3568187-1073c8)](https://doi.org/10.5281/zenodo.3568187)
-[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A522.10.1-23aa62.svg)](https://www.nextflow.io/)
+[![Nextflow](https://img.shields.io/badge/nextflow%20DSL2-%E2%89%A523.04.0-23aa62.svg)](https://www.nextflow.io/)
 [![run with conda](http://img.shields.io/badge/run%20with-conda-3EB049?labelColor=000000&logo=anaconda)](https://docs.conda.io/en/latest/)
 [![run with docker](https://img.shields.io/badge/run%20with-docker-0db7ed?labelColor=000000&logo=docker)](https://www.docker.com/)
 [![run with singularity](https://img.shields.io/badge/run%20with-singularity-1d355c.svg?labelColor=000000)](https://sylabs.io/docs/)

--- a/nextflow.config
+++ b/nextflow.config
@@ -229,8 +229,9 @@ process.shell = ['/bin/bash', '-euo', 'pipefail']
 // Set default registry for Docker and Podman independent of -profile
 // Will not be used unless Docker / Podman are enabled
 // Set to your registry if you have a mirror of containers
-docker.registry = 'quay.io'
-podman.registry = 'quay.io'
+singularity.registry = 'quay.io'
+docker.registry      = 'quay.io'
+podman.registry      = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {
@@ -256,8 +257,8 @@ manifest {
     homePage        = 'https://github.com/nf-core/scrnaseq'
     description     = """Pipeline for processing 10x Genomics single cell rnaseq data"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=22.10.1'
-    version         = '2.3.2'
+    nextflowVersion = '!>=23.04.0'
+    version         = '2.4.0dev'
     doi             = '10.5281/zenodo.3568187'
 }
 


### PR DESCRIPTION
See https://github.com/nf-core/modules/pull/3499

Needed in this pipeline to correctly pull and convert Docker images hosted in the nf-core `quay.io` registry.