### PR TITLE
fix (231): Null object accessed in multiqc channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## dev
+
+- Fix issue where multiqc inputs tried to access objects that did not exist.
+
 ## v2.3.2 - 2023-06-07 Patched Yellow Strontium Pinscher
 
 - Move containers for pipeline to quay.io ([#233](https://github.com/nf-core/scrnaseq/pull/233))

--- a/subworkflows/local/alevin.nf
+++ b/subworkflows/local/alevin.nf
@@ -40,8 +40,8 @@ workflow SCRNASEQ_ALEVIN {
         transcript_tsv = SIMPLEAF_INDEX.out.transcript_tsv.collect()
         ch_versions = ch_versions.mix(SIMPLEAF_INDEX.out.versions)
 
-        if (!txp2gene) { 
-            txp2gene = SIMPLEAF_INDEX.out.transcript_tsv 
+        if (!txp2gene) {
+            txp2gene = SIMPLEAF_INDEX.out.transcript_tsv
         }
     }
 
@@ -69,5 +69,4 @@ workflow SCRNASEQ_ALEVIN {
     ch_versions
     alevin_results = SIMPLEAF_QUANT.out.alevin_results
     alevinqc = ALEVINQC.out.report
-    for_multiqc = SIMPLEAF_QUANT.out.alevin_results.collect{it[1]}.ifEmpty([])
 }

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -231,13 +231,17 @@ workflow SCRNASEQ {
     methods_description    = WorkflowScrnaseq.methodsDescriptionText(workflow, ch_multiqc_custom_methods_description)
     ch_methods_description = Channel.value(methods_description)
 
+    ch_multiqc_fastqc.dump(tag: 'fastqc', pretty: true)
+    ch_multiqc_alevin.dump(tag: 'alevin', pretty: true)
+    ch_multiqc_star.dump(tag: 'star', pretty: true)
+
     ch_multiqc_files = Channel.empty()
     ch_multiqc_files = ch_multiqc_files.mix(ch_workflow_summary.collectFile(name: 'workflow_summary_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(ch_methods_description.collectFile(name: 'methods_description_mqc.yaml'))
     ch_multiqc_files = ch_multiqc_files.mix(CUSTOM_DUMPSOFTWAREVERSIONS.out.mqc_yml.collect())
-    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_fastqc.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_alevin.collect{it[1]}.ifEmpty([]))
-    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_star.collect{it[1]}.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_fastqc.collect{ meta, qcfile -> qcfile }.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_alevin.collect{ meta, qcfile -> qcfile }.ifEmpty([]))
+    ch_multiqc_files = ch_multiqc_files.mix(ch_multiqc_star.collect{ meta, qcfile -> qcfile }.ifEmpty([]))
 
     MULTIQC (
         ch_multiqc_files.collect(),

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -158,7 +158,7 @@ workflow SCRNASEQ {
             ch_fastq
         )
         ch_versions = ch_versions.mix(SCRNASEQ_ALEVIN.out.ch_versions)
-        ch_multiqc_alevin = SCRNASEQ_ALEVIN.out.for_multiqc
+        ch_multiqc_alevin = SCRNASEQ_ALEVIN.out.alevin_results
         ch_mtx_matrices = ch_mtx_matrices.mix(SCRNASEQ_ALEVIN.out.alevin_results)
     }
 


### PR DESCRIPTION
- Fix issue with multiqc channel trying to access null objects
- add explicit channel values to handle multiqc inputs

<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
