### PR TITLE
Add `check_max` to AlevinQC time limit

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -166,9 +166,10 @@ if (params.aligner == "alevin") {
             ]
             ext.args = "-r cr-like"
         }
-        //Fix for issue 196
+        // Fix for issue 196
+        // Modified for issue 334
         withName: 'ALEVINQC' {
-            time = '120.h'
+            time = { check_max( 120.h, 'time' ) }
         }
     }
 }


### PR DESCRIPTION
This solves #334.

We could add `task.attempt` as a factor here, but I don't know if this is desirable since `120.h` is quite long already.