### PR TITLE
Fix: fb_reference

### DIFF
--- a/subworkflows/local/align_cellrangermulti.nf
+++ b/subworkflows/local/align_cellrangermulti.nf
@@ -43,7 +43,11 @@ workflow CELLRANGER_MULTI_ALIGN {
                 vdj: meta.feature_type == "vdj"
                     return [ meta, fastq ]
                 ab: meta.feature_type == "ab"
-                    return [ meta, fastq ]
+                    if (params.fb_reference){
+                        return [ meta, fastq ]
+                    } else {
+                        error ("Antibody reference was not specified. Please provide a reference file for feature barcoding (e.g. antibody measurements).\nPlease refer to https://www.10xgenomics.com/support/software/cell-ranger/latest/analysis/inputs/cr-feature-ref-csv for more details.")
+                    }
                 beam: meta.feature_type == "beam"
                     return [ meta, fastq ]
                 crispr: meta.feature_type == "crispr"


### PR DESCRIPTION
#### Scenario:
Sample sheet contains feature_type 'ab' but feature ref was null. Pipeline runs to completion but skips feature barcoding. 
#### Fix:
If sample sheet contains 'ab' but no fb ref is supplied, an error message should be raised.