### PR TITLE
Add pre-built indexes for Cellranger, Cellranger-arc, simpleaf and simpleaf txp2gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for pre-built indexes in `genomes.config` file for `cellranger`, `cellranger-arc`, `simpleaf` and `simpleaf txp2gene` ([#371](https://github.com/nf-core/scrnaseq/issues/371))
+
 ## v2.7.1 - 2024-08-13
 
 - Fix that tests have not been executed with nf-test v0.9 ([#359](https://github.com/nf-core/scrnaseq/pull/359))

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -50,7 +50,7 @@ workflow SCRNASEQ {
     }
     else if (params.aligner == "cellrangerarc") {
         params.cellranger_index = getGenomeAttribute('cellrangerarc')
-    } 
+    }
 
     ch_genome_fasta = params.fasta ? file(params.fasta, checkIfExists: true) : []
     ch_gtf = params.gtf ? file(params.gtf, checkIfExists: true) : []

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -43,7 +43,7 @@ workflow SCRNASEQ {
     params.star_index       = getGenomeAttribute('star')
     params.salmon_index     = getGenomeAttribute('simpleaf')
     params.txp2gene         = getGenomeAttribute('simpleaf_tx2pgene')
-    
+
     // Make cellranger or cellranger-arc index conditional
     if (params.aligner in ["cellranger", "cellrangermulti"]){
         params.cellranger_index = getGenomeAttribute('cellranger')

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -43,11 +43,14 @@ workflow SCRNASEQ {
     params.star_index       = getGenomeAttribute('star')
     params.salmon_index     = getGenomeAttribute('simpleaf')
     params.txp2gene         = getGenomeAttribute('simpleaf_tx2pgene')
-    params.cellranger_index = getGenomeAttribute('cellranger')
-    // Make cellranger-arc index overwriting conditional
-    if (params.aligner == "cellrangerarc") {
-        params.cellranger_index = getGenomeAttribute('cellrangerarc')
+    
+    // Make cellranger or cellranger-arc index conditional
+    if (params.aligner in ["cellranger", "cellrangermulti"]){
+        params.cellranger_index = getGenomeAttribute('cellranger')
     }
+    else if (params.aligner == "cellrangerarc") {
+        params.cellranger_index = getGenomeAttribute('cellrangerarc')
+    } 
 
     ch_genome_fasta = params.fasta ? file(params.fasta, checkIfExists: true) : []
     ch_gtf = params.gtf ? file(params.gtf, checkIfExists: true) : []

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -37,7 +37,7 @@ workflow SCRNASEQ {
         error "Only cellranger supports `protocol = 'auto'`. Please specify the protocol manually!"
     }
 
-    // collecting paths from genome attributes (optional)
+    // collect paths from genome attributes file (e.g. iGenomes.config; optional)
     params.fasta            = getGenomeAttribute('fasta')
     params.gtf              = getGenomeAttribute('gtf')
     params.star_index       = getGenomeAttribute('star')

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -37,9 +37,14 @@ workflow SCRNASEQ {
         error "Only cellranger supports `protocol = 'auto'`. Please specify the protocol manually!"
     }
 
-    params.fasta = getGenomeAttribute('fasta')
-    params.gtf = getGenomeAttribute('gtf')
-    params.star_index = getGenomeAttribute('star')
+    // collecting paths from genome attributes (optional)
+    params.fasta            = getGenomeAttribute('fasta')
+    params.gtf              = getGenomeAttribute('gtf')
+    params.star_index       = getGenomeAttribute('star')
+    params.salmon_index     = getGenomeAttribute('simpleaf')
+    params.txp2gene         = getGenomeAttribute('simpleaf_tx2pgene')
+    params.cellranger_index = getGenomeAttribute('cellranger')
+    params.cellranger_index = getGenomeAttribute('cellrangerarc')
 
     ch_genome_fasta = params.fasta ? file(params.fasta, checkIfExists: true) : []
     ch_gtf = params.gtf ? file(params.gtf, checkIfExists: true) : []

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -44,7 +44,10 @@ workflow SCRNASEQ {
     params.salmon_index     = getGenomeAttribute('simpleaf')
     params.txp2gene         = getGenomeAttribute('simpleaf_tx2pgene')
     params.cellranger_index = getGenomeAttribute('cellranger')
-    params.cellranger_index = getGenomeAttribute('cellrangerarc')
+    // Make cellranger-arc index overwriting conditional
+    if (params.aligner == "cellrangerarc") {
+        params.cellranger_index = getGenomeAttribute('cellrangerarc')
+    }
 
     ch_genome_fasta = params.fasta ? file(params.fasta, checkIfExists: true) : []
     ch_gtf = params.gtf ? file(params.gtf, checkIfExists: true) : []


### PR DESCRIPTION
<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

As outlined in #371, we would like to enable the (re-)use of pre-computed index files from a supplied genome configuration file (such as `igenomes.config`). This fairly minimal should result in a considerable reduction in compute time and cost, thus substantially reducing a run's carbon footprint.  

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
