### PR TITLE
Fix cellrangermulti handling of crispr data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for pre-built indexes in `genomes.config` file for `cellranger`, `cellranger-arc`, `simpleaf` and `simpleaf txp2gene` ([#371](https://github.com/nf-core/scrnaseq/issues/371))
 - Cleanup and fix bugs in matrix conversion code, and change to use anndataR for conversions, and cellbender for emptydrops call. ([#369](https://github.com/nf-core/scrnaseq/pull/369))
 - Fix problem with `test_full` that was not running out of the box, since code was trying to overwrite parameters in the workflow, which is not possible ([#366](https://github.com/nf-core/scrnaseq/issues/366))
+- Fix bug in CRISPR data handling by `cellranger multi` ([#401](https://github.com/nf-core/scrnaseq/issues/401) 
 
 ## v2.7.1 - 2024-08-13
 

--- a/modules/nf-core/cellranger/multi/main.nf
+++ b/modules/nf-core/cellranger/multi/main.nf
@@ -59,7 +59,7 @@ process CELLRANGER_MULTI {
     include_vdj  = vdj_fastqs.first().getName() != 'fastqs' && vdj_reference           ? '[vdj]'                 : ''
     include_beam = beam_fastqs.first().getName() != 'fastqs' && beam_control_panel     ? '[antigen-specificity]' : ''
     include_cmo  = cmo_fastqs.first().getName() != 'fastqs' && cmo_barcodes            ? '[samples]'             : ''
-    include_fb   = ab_fastqs.first().getName() != 'fastqs' && fb_reference             ? '[feature]'             : ''
+    include_fb = (ab_fastqs.first().getName() != 'fastqs' || crispr_fastqs.first().getName() != 'fastqs') && fb_reference ? '[feature]' : ''
     include_frna = gex_frna_probeset_name && frna_sampleinfo                           ? '[samples]'             : ''
 
     gex_reference_path = include_gex ? "reference,./${gex_reference_name}" : ''

--- a/modules/nf-core/cellranger/multi/templates/cellranger_multi.py
+++ b/modules/nf-core/cellranger/multi/templates/cellranger_multi.py
@@ -29,7 +29,7 @@ fastq_all.mkdir(exist_ok=True)
 # do not match "SRR12345", "file_INFIXR12", etc
 filename_pattern = r"([^a-zA-Z0-9])R1([^a-zA-Z0-9])"
 
-for modality in ["gex", "vdj", "ab", "beam", "cmo", "cirspr"]:
+for modality in ["gex", "vdj", "ab", "beam", "cmo", "crispr"]:
     # get fastqs, ordered by path. Files are staged into
     #   - "fastq_001/{original_name.fastq.gz}"
     #   - "fastq_002/{original_name.fastq.gz}"


### PR DESCRIPTION
## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests! --> A test will be submitted through a different PR pending the approval of [PR 1415](https://github.com/nf-core/test-datasets/pull/1415)
- [x] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository. --> [PR 1415](https://github.com/nf-core/test-datasets/pull/1415)
- [ ] Make sure your code lints (`nf-core lint`). --> Code fixes lint properly. However, the linter reports one preexisting error and multiple preexisting warnings that may need to be addressed separately.
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.

The proposed changes are described in [issue 401](https://github.com/nf-core/scrnaseq/issues/401) and intended to fix a bug that prevents handling of CRISPR data when using `cellranger multi` with gene expression and CRISPR libraries.

The addition of a test dataset with CRISPR data has been requested in [PR 1415](https://github.com/nf-core/test-datasets/pull/1415). A dedicated test for CRISPR data handling by `cellranger multi` will be submitted in a separate PR once the test dataset is approved.