### PR TITLE
Fix problematic star index channel structure if params.star_index is provided

### DIFF
--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -87,7 +87,7 @@ workflow SCRNASEQ {
 
     //star params
     star_index = star_index ? file(star_index, checkIfExists: true) : null
-    ch_star_index = star_index ? Channel.of( [[id: star_index.baseName], star_index] ) : []
+    ch_star_index = star_index ? Channel.value( [[id: star_index.baseName], star_index] ) : []
     star_feature = params.star_feature
 
     //cellranger params


### PR DESCRIPTION
With the `channel.of` that was previously used, a [queue channel](https://www.nextflow.io/docs/latest/channel.html#channel-types) with a single entry was created. Thus, only one sample was processed. Switched to `channel.value`, so that a value channel is created, fixing this problematic behavior.