### PR TITLE
fix fasta reference flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Now, you can run the pipeline using:
 nextflow run nf-core/scrnaseq \
    -profile <docker/singularity/.../institute> \
    --input samplesheet.csv \
-   --genome_fasta GRCm38.p6.genome.chr19.fa \
+   --fasta GRCm38.p6.genome.chr19.fa \
    --gtf gencode.vM19.annotation.chr19.gtf \
    --protocol 10XV2 \
    --aligner <alevin/kallisto/star/cellranger> \


### PR DESCRIPTION
I noticed the example in the README seems to use an old syntax that is no longer supported. I fixed the example to use the current syntax for specifying the reference fasta (should be `--fasta`, not `--genome_fasta`).

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [X] `README.md` is updated (including new tool citations and authors/contributors).
