### PR TITLE
fix: prevent additional path splitting for txp2gene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix of additional path splitting for `txp2gene` ([433](https://github.com/nf-core/scrnaseq/pull/433))
 - Add a checker so that `--fb_reference` does not break the pipeline in case `ab` files are not used in `cellranger multi` sub-workflow.
 - Fix concatenation of multiple samples into the combined output AnnData ([416](https://github.com/nf-core/scrnaseq/pull/416))
 - Make sure STARsolo velocity output is added to the combined output AnnData, if `star_feature = 'Gene Velocyto'` ([417](https://github.com/nf-core/scrnaseq/pull/417))

--- a/subworkflows/local/kallisto_bustools.nf
+++ b/subworkflows/local/kallisto_bustools.nf
@@ -69,6 +69,6 @@ workflow KALLISTO_BUSTOOLS {
     counts          = KALLISTOBUSTOOLS_COUNT.out.count
     counts_raw      = ch_raw_counts
     counts_filtered = ch_filtered_counts
-    txp2gene        = txp2gene.collect()
+    txp2gene        = txp2gene
 
 }


### PR DESCRIPTION
Hi, when providing reference for kallisto workflow, txp2gene is "collected" twice in the code, meaning the path will further split, resulting in an error.

Example:

```yaml
txp2gene = '/maps/projects/dan1/data/Brickman/shared/references/mus_musculus/10x/refdata-gex-GRCm39-2024-A/kb/t2g.txt'
```

Outcome
```
FileNotFoundError: [Errno 2] No such file or directory: 'maps projects dan1 data Brickman shared references mus_musculus 10x refdata-gex-GRCm39-2024-A kb t2g.txt'
```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
