### PR TITLE
docs: move 'txp2gene' to 'reference_genome_options' because it is shared between alevin and kallisto/bus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Move `txp2gene` to `reference_genome_options` in schema as it is required by `kb_python` and `alevin` ([434](https://github.com/nf-core/scrnaseq/pull/434))
 - Fix of additional path splitting for `txp2gene` ([433](https://github.com/nf-core/scrnaseq/pull/433))
 - Add a checker so that `--fb_reference` does not break the pipeline in case `ab` files are not used in `cellranger multi` sub-workflow.
 - Fix concatenation of multiple samples into the combined output AnnData ([416](https://github.com/nf-core/scrnaseq/pull/416))

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -155,7 +155,14 @@
                     "default": "s3://ngi-igenomes/igenomes/",
                     "fa_icon": "fas fa-cloud-download-alt",
                     "hidden": true
-                }
+                },
+                "txp2gene": {
+                     "type": "string",
+                     "description": "Path to transcript to gene mapping file. This allows the specification of a transcript to gene mapping file for Kallisto/BUS and Alevin-fry with AlevinQC.",
+                     "fa_icon": "fas fa-map-marked-alt",
+                     "format": "file-path",
+                     "exists": true
+                 }
             }
         },
         "simpleaf_options": {
@@ -170,14 +177,6 @@
                     "description": "Path to pre-built Simpleaf index.",
                     "fa_icon": "fas fa-fish",
                     "format": "path",
-                    "exists": true
-                },
-                "txp2gene": {
-                    "type": "string",
-                    "description": "Path to transcript to gene mapping file.",
-                    "help_text": "This allows the specification of a transcript to gene mapping file for Simpleaf. Only required if the index is generated from a transcriptomic reference FASTA file (`transcript_fasta`).",
-                    "fa_icon": "fas fa-map-marked-alt",
-                    "format": "file-path",
                     "exists": true
                 },
                 "simpleaf_umi_resolution": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -157,12 +157,12 @@
                     "hidden": true
                 },
                 "txp2gene": {
-                     "type": "string",
-                     "description": "Path to transcript to gene mapping file. This allows the specification of a transcript to gene mapping file for Kallisto/BUS and Alevin-fry with AlevinQC.",
-                     "fa_icon": "fas fa-map-marked-alt",
-                     "format": "file-path",
-                     "exists": true
-                 }
+                    "type": "string",
+                    "description": "Path to transcript to gene mapping file. This allows the specification of a transcript to gene mapping file for Kallisto/BUS and Alevin-fry with AlevinQC.",
+                    "fa_icon": "fas fa-map-marked-alt",
+                    "format": "file-path",
+                    "exists": true
+                }
             }
         },
         "simpleaf_options": {


### PR DESCRIPTION
move 'txp2gene' to 'reference_genome_options' because it is shared between alevin and kallisto/bus

<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
