### PR TITLE
change publishing detail of simpleaf results

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -133,7 +133,8 @@ if ( params.aligner == "simpleaf" ) {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}" },
                 mode: params.publish_dir_mode,
-                enabled: params.save_reference
+                enabled: params.save_reference,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
             ext.prefix = { "simpleaf_index" }
 
@@ -142,7 +143,7 @@ if ( params.aligner == "simpleaf" ) {
             publishDir = [
                 path: { "${params.outdir}/${params.aligner}/${meta.id}" },
                 mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+                saveAs: { filename -> (filename.contains('af_map') && !params.save_align_intermeds) || filename.equals('versions.yml') ? null :  filename }
             ]
             ext.prefix = { "simpleaf_quant" }
 
@@ -151,8 +152,9 @@ if ( params.aligner == "simpleaf" ) {
         // Modified for issue 334
         withName: 'ALEVINQC' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/${meta.id}" },
+                path: { "${params.outdir}/${params.aligner}/${meta.id}/alevinqc" },
                 mode: params.publish_dir_mode,
+                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]
             time = { 120.h }
         }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -152,7 +152,7 @@ if ( params.aligner == "simpleaf" ) {
         // Modified for issue 334
         withName: 'ALEVINQC' {
             publishDir = [
-                path: { "${params.outdir}/${params.aligner}/${meta.id}/alevinqc" },
+                path: { "${params.outdir}/${params.aligner}/${meta.id}" },
                 mode: params.publish_dir_mode,
                 saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
             ]


### PR DESCRIPTION
Addressing my question here  https://github.com/nf-core/scrnaseq/pull/439#discussion_r1983751028. When `save_align_intermeds = true`, the output folder, `af_map`, will not be published.

Still, the current solution is not optimal because, as the name suggests, `save_align_intermeds` deals with BAM **files** or equivalent. In simpleaf, there are two "intermediate" alignment files, `af_map/map.rad` and `af_quant/map.collated.rad`. These two files are under the two output **directories**, `af_map` and `af_quant`, respectively. Therefore, instead of ignoring the `af_map` directory when publishing, it will be great if we can find a way to ignore only these two alignment files ending with `.rad`. See my slack message here https://nfcore.slack.com/archives/CJRH30T6V/p1741281517210619

Another note is that, i tried `filename.equal("af_map")` but it failed to identify this directory. Is the syntax of providing a directory name different than a file name? 