### PR TITLE
Fix refgenome error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix simpleaf protocol name for 10xv4 ([#452](https://github.com/nf-core/scrnaseq/pull/452))
 - Fix the workflow for cellranger-arc alignment and add new test with 10x multiome dataset ([#441](https://github.com/nf-core/scrnaseq/pull/441))
 - Update `nf-core/cellranger` modules to tool verson `9.0.1` ([#467](https://github.com/nf-core/scrnaseq/pull/467)).
+- Fix igenomes usage to correctly handle fasta and gtf files ([#469](https://github.com/nf-core/scrnaseq/pull/469)).
 
 ### Chore
 

--- a/main.nf
+++ b/main.nf
@@ -52,6 +52,8 @@ workflow NFCORE_SCRNASEQ {
     //
     SCRNASEQ (
         samplesheet,
+        params.fasta,
+        params.gtf
     )
     emit:
     multiqc_report = SCRNASEQ.out.multiqc_report // channel: /path/to/multiqc_report.html

--- a/main.nf
+++ b/main.nf
@@ -30,11 +30,6 @@ include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrn
 // Thus, manually provided files are not overwritten by the genome attributes
 params.fasta            = getGenomeAttribute('fasta')
 params.gtf              = getGenomeAttribute('gtf')
-params.simpleaf_index   = getGenomeAttribute('simpleaf') ?: getGenomeAttribute('salmon')
-params.txp2gene         = getGenomeAttribute('simpleaf_txp2gene')
-params.cellranger_index = params.aligner == 'cellrangerarc' ?
-                            getGenomeAttribute('cellrangerarc') :
-                            getGenomeAttribute('cellranger')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,8 +20,6 @@ params {
     genome            = null
     transcript_fasta  = null
     txp2gene          = null
-    fasta             = null
-    gtf               = null
 
     // simpleaf parameters
     simpleaf_index      = null

--- a/subworkflows/local/starsolo.nf
+++ b/subworkflows/local/starsolo.nf
@@ -7,8 +7,6 @@ include { GUNZIP }                      from '../../modules/nf-core/gunzip/main'
 include { STAR_GENOMEGENERATE }         from '../../modules/nf-core/star/genomegenerate/main'
 
 
-def multiqc_report    = []
-
 workflow STARSOLO {
     take:
     genome_fasta

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -28,6 +28,8 @@ workflow SCRNASEQ {
 
     take:
     ch_fastq
+    fasta
+    gtf
 
     main:
     ch_multiqc_files = Channel.empty()
@@ -40,8 +42,8 @@ workflow SCRNASEQ {
     }
 
     // general input and params
-    ch_genome_fasta         = params.fasta                ? file(params.fasta, checkIfExists: true)    : []
-    ch_gtf                  = params.gtf                  ? file(params.gtf, checkIfExists: true)      : []
+    ch_genome_fasta         = fasta                       ? file(fasta, checkIfExists: true)    : []
+    ch_gtf                  = gtf                         ? file(gtf, checkIfExists: true)      : []
     ch_transcript_fasta     = params.transcript_fasta     ? file(params.transcript_fasta)              : []
     ch_motifs               = params.motifs               ? file(params.motifs)                        : []
     ch_txp2gene             = params.txp2gene             ? file(params.txp2gene, checkIfExists: true) : []
@@ -91,8 +93,8 @@ workflow SCRNASEQ {
     //
     // Uncompress genome fasta file if required
     //
-    if (params.fasta) {
-        if (params.fasta.endsWith('.gz')) {
+    if (fasta) {
+        if (fasta.endsWith('.gz')) {
             ch_genome_fasta    = GUNZIP_FASTA ( [ [:], ch_genome_fasta ] ).gunzip.map { it[1] }
             ch_versions        = ch_versions.mix(GUNZIP_FASTA.out.versions)
         } else {
@@ -103,8 +105,8 @@ workflow SCRNASEQ {
     //
     // Uncompress GTF annotation file or create from GFF3 if required
     //
-    if (params.gtf) {
-        if (params.gtf.endsWith('.gz')) {
+    if (gtf) {
+        if (gtf.endsWith('.gz')) {
             ch_gtf      = GUNZIP_GTF ( [ [:], ch_gtf ] ).gunzip.map { it[1] }
             ch_versions = ch_versions.mix(GUNZIP_GTF.out.versions)
         } else {


### PR DESCRIPTION
Based on [this](https://nfcore.slack.com/archives/CHN5BV5DW/p1748603437716269) slack thread. Igenomes was not correctly implemented in the pipeline, basically providing a genome using igenomes did not have any effect. 

I checked what is different in comparison to nf-core/rnaseq and adjusted accordingly. 