### PR TITLE
Refactor iGenomes handling to expose params object pipeline-wide

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -11,17 +11,6 @@
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS / WORKFLOWS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
-include { SCRNASEQ                } from './workflows/scrnaseq'
-include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
-include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     GENOME PARAMETER VALUES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -30,6 +19,17 @@ include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrn
 // Thus, manually provided files are not overwritten by the genome attributes
 params.fasta            = getGenomeAttribute('fasta')
 params.gtf              = getGenomeAttribute('gtf')
+params.star_index       = getGenomeAttribute('star')
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS / WORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+include { SCRNASEQ                } from './workflows/scrnaseq'
+include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,9 +51,7 @@ workflow NFCORE_SCRNASEQ {
     // WORKFLOW: Run pipeline
     //
     SCRNASEQ (
-        samplesheet,
-        params.fasta,
-        params.gtf
+        samplesheet
     )
     emit:
     multiqc_report = SCRNASEQ.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -97,6 +95,21 @@ workflow {
         params.hook_url,
         NFCORE_SCRNASEQ.out.multiqc_report
     )
+}
+
+//
+// Get attribute from genome config file e.g. fasta
+//
+def getGenomeAttribute(attribute) {
+    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
+        if (params.genomes[ params.genome ].containsKey(attribute)) {
+            return params.genomes[ params.genome ][ attribute ]
+        } else {
+            return null
+        }
+    } else {
+        return null
+    }
 }
 
 /*

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,7 +33,6 @@ params {
     kb_t2c            = null
 
     // STARsolo parameters
-    star_index          = null
     star_ignore_sjdbgtf = null
     seq_center          = null
     star_feature        = "Gene"

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -249,20 +249,6 @@ def cellrangerarcStructure(input) {
 
     return [ sampleMeta, sampletypes, subsamples, fastqs.flatten() ]
 }
-//
-// Get attribute from genome config file e.g. fasta
-//
-def getGenomeAttribute(attribute) {
-    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
-        if (params.genomes[ params.genome ].containsKey(attribute)) {
-            return params.genomes[ params.genome ][ attribute ]
-        } else {
-            return null
-        }
-    } else {
-        return null
-    }
-}
 
 //
 // Exit pipeline if incorrect --genome key provided

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -249,6 +249,20 @@ def cellrangerarcStructure(input) {
 
     return [ sampleMeta, sampletypes, subsamples, fastqs.flatten() ]
 }
+//
+// Get attribute from genome config file e.g. fasta
+//
+def getGenomeAttribute(attribute) {
+    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
+        if (params.genomes[ params.genome ].containsKey(attribute)) {
+            return params.genomes[ params.genome ][ attribute ]
+        } else {
+            return null
+        }
+    } else {
+        return null
+    }
+}
 
 //
 // Exit pipeline if incorrect --genome key provided

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -28,8 +28,6 @@ workflow SCRNASEQ {
 
     take:
     ch_fastq
-    fasta
-    gtf
 
     main:
     ch_multiqc_files = Channel.empty()
@@ -42,8 +40,8 @@ workflow SCRNASEQ {
     }
 
     // general input and params
-    ch_genome_fasta         = fasta                       ? file(fasta, checkIfExists: true)    : []
-    ch_gtf                  = gtf                         ? file(gtf, checkIfExists: true)      : []
+    ch_genome_fasta         = params.fasta                ? file(params.fasta, checkIfExists: true)    : []
+    ch_gtf                  = params.gtf                  ? file(params.gtf, checkIfExists: true)      : []
     ch_transcript_fasta     = params.transcript_fasta     ? file(params.transcript_fasta)              : []
     ch_motifs               = params.motifs               ? file(params.motifs)                        : []
     ch_txp2gene             = params.txp2gene             ? file(params.txp2gene, checkIfExists: true) : []
@@ -93,8 +91,8 @@ workflow SCRNASEQ {
     //
     // Uncompress genome fasta file if required
     //
-    if (fasta) {
-        if (fasta.endsWith('.gz')) {
+    if (params.fasta) {
+        if (params.fasta.endsWith('.gz')) {
             ch_genome_fasta    = GUNZIP_FASTA ( [ [:], ch_genome_fasta ] ).gunzip.map { it[1] }
             ch_versions        = ch_versions.mix(GUNZIP_FASTA.out.versions)
         } else {
@@ -105,8 +103,8 @@ workflow SCRNASEQ {
     //
     // Uncompress GTF annotation file or create from GFF3 if required
     //
-    if (gtf) {
-        if (gtf.endsWith('.gz')) {
+    if (params.gtf) {
+        if (params.gtf.endsWith('.gz')) {
             ch_gtf      = GUNZIP_GTF ( [ [:], ch_gtf ] ).gunzip.map { it[1] }
             ch_versions = ch_versions.mix(GUNZIP_GTF.out.versions)
         } else {


### PR DESCRIPTION
This PR builds on: https://github.com/nf-core/scrnaseq/pull/469

It moves the `getGenomeAttribute` function to `main.nf`, making igenomes-derived parameters available pipeline-wide rather than just within main.nf as described by @nictru in the linked PR. This eliminates the need to manually pass parameters to subworkflows, simplifying the addition of new iGenomes attributes. Currently, only `fasta`, `gtf`, and `star_index` are supported.

Additionally I had to move the imports below the igenomes fetching, as the `getGenomeAttribute` is otherwise not available.

The changes align with implementations in nf-core/tfactivity (https://github.com/nf-core/tfactivity/pull/30)
and nf-core/rnaseq ([nf-core/rnaseq/main.nf#L184](https://github.com/nf-core/rnaseq/blob/master/main.nf#L184)).


<!--
# nf-core/scrnaseq pull request

Many thanks for contributing to nf-core/scrnaseq!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
