### PR TITLE
SmartSeq - Bugfixes

### DIFF
--- a/modules/local/anndatar_convert/main.nf
+++ b/modules/local/anndatar_convert/main.nf
@@ -17,7 +17,7 @@ process ANNDATAR_CONVERT {
     tuple val(meta), path(h5ad)
 
     output:
-    tuple val(meta), path("${meta.id}_${meta.input_type}_matrix*.rds"), emit: rds
+    tuple val(meta), path("${meta.id}_${meta.input_type}_matrix*.rds"), emit: rds, optional: true
     path  "versions.yml"                                              , emit: versions
 
     when:

--- a/modules/local/anndatar_convert/templates/anndatar_convert.R
+++ b/modules/local/anndatar_convert/templates/anndatar_convert.R
@@ -9,20 +9,27 @@ library(SingleCellExperiment)
 
 # read input
 adata <- read_h5ad("${h5ad}")
+print("Read in ${h5ad} successfully.")
+print(adata)
 
-# convert to Seurat
-obj <- adata\$as_Seurat()
+# If there is only 1 cell
+if(adata\$shape()[1] == 1) {
+    print("The input file contains only one cell. Cannot create Seurat object.")
+} else {
+    # convert to Seurat
+    obj <- adata\$as_Seurat()
 
-# save files
-dir.create(file.path("$meta.id"), showWarnings = FALSE)
-saveRDS(obj, file = "${meta.id}_${meta.input_type}_matrix.seurat.rds")
+    # save files
+    dir.create(file.path("$meta.id"), showWarnings = FALSE)
+    saveRDS(obj, file = "${meta.id}_${meta.input_type}_matrix.seurat.rds")
 
-# convert to SingleCellExperiment
-obj <- adata\$as_SingleCellExperiment()
+    # convert to SingleCellExperiment
+    obj <- adata\$as_SingleCellExperiment()
 
-# save files
-dir.create(file.path("$meta.id"), showWarnings = FALSE)
-saveRDS(obj, file = "${meta.id}_${meta.input_type}_matrix.sce.rds")
+    # save files
+    dir.create(file.path("$meta.id"), showWarnings = FALSE)
+    saveRDS(obj, file = "${meta.id}_${meta.input_type}_matrix.sce.rds")
+}
 
 #
 # save versions file

--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -29,7 +29,7 @@ process STAR_ALIGN {
     tuple val(meta), path('*d.out.bam')                            , emit: bam
     tuple val(meta), path('*.Solo.out')                            , emit: counts
     tuple val(meta), path ("*.Solo.out/Gene*/raw")                 , emit: raw_counts
-    tuple val(meta), path ("*.Solo.out/Gene*/filtered")            , emit: filtered_counts
+    tuple val(meta), path ("*.Solo.out/Gene*/filtered")            , emit: filtered_counts, optional: true
     tuple val(meta), path ("*.Solo.out/Velocyto/velocyto_raw")     , emit: raw_velocyto, optional:true
     tuple val(meta), path ("*.Solo.out/Velocyto/velocyto_filtered"), emit: filtered_velocyto, optional:true
     tuple val(meta), path('*Log.final.out')                        , emit: log_final

--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -75,6 +75,12 @@ process STAR_ALIGN {
         echo "Whitelist file provided - $whitelist." >&2
     fi
 
+    # If the SmartSeq protocol is used,  set soloUMIdedup to NoDedup
+    if [[ "$protocol" == "SmartSeq" ]]; then
+        echo "SmartSeq protocol detected, setting --soloUMIdedup to NoDedup." >&2
+        soloUMIdedupArg="--soloUMIdedup NoDedup"
+    fi
+
     STAR \\
         --genomeDir $index \\
         --readFilesIn ${reverse.join( "," )} ${forward.join( "," )} \\
@@ -83,6 +89,7 @@ process STAR_ALIGN {
         \$soloCBwhitelistArg \\
         --soloType $protocol \\
         --soloFeatures $star_feature \\
+        \$soloUMIdedupArg \\
         $other_10x_parameters \\
         $out_sam_type \\
         $ignore_gtf \\

--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -79,6 +79,8 @@ process STAR_ALIGN {
     if [[ "$protocol" == "SmartSeq" ]]; then
         echo "SmartSeq protocol detected, setting --soloUMIdedup to NoDedup." >&2
         soloUMIdedupArg="--soloUMIdedup NoDedup"
+    else
+        soloUMIdedupArg=""
     fi
 
     STAR \\

--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -61,10 +61,18 @@ process STAR_ALIGN {
     // separate forward from reverse pairs
     def (forward, reverse) = reads.collate(2).transpose()
     """
-    if [[ $whitelist == *.gz ]]; then
-        gzip -cdf $whitelist > whitelist.uncompressed.txt
+    # If the whitelist was not provided
+    if [[ -z "$whitelist" ]]; then
+        echo "Whitelist file not provided." >&2
+        soloCBwhitelistArg=""
     else
-        cp $whitelist whitelist.uncompressed.txt
+        if [[ "$whitelist" == *.gz ]]; then
+            gzip -cdf "$whitelist" > whitelist.uncompressed.txt
+        else
+            cp "$whitelist" whitelist.uncompressed.txt
+        fi
+        soloCBwhitelistArg="--soloCBwhitelist whitelist.uncompressed.txt"
+        echo "Whitelist file provided - $whitelist." >&2
     fi
 
     STAR \\
@@ -72,7 +80,7 @@ process STAR_ALIGN {
         --readFilesIn ${reverse.join( "," )} ${forward.join( "," )} \\
         --runThreadN $task.cpus \\
         --outFileNamePrefix $prefix. \\
-        --soloCBwhitelist whitelist.uncompressed.txt \\
+        \$soloCBwhitelistArg \\
         --soloType $protocol \\
         --soloFeatures $star_feature \\
         $other_10x_parameters \\


### PR DESCRIPTION
While using this pipeline to analyze some SmartSeq data, I ran into a couple of issues that needed to be addressed. This PR contains fixes for a small number of minor issues:

- When running the STARsolo tool, account for the case where no whitelist file is provided
- If the SmartSeq protocol is used,  set soloUMIdedup to NoDedup
- If only 1 cell is detected, skip the Seurat conversion (since that is a documented limitation of Seurat)
- When running the STARsolo tool, account for case where no reads pass filtering

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] `CHANGELOG.md` is updated.
