### PR TITLE
STAR: Add support for no/multiple whitelist files

### DIFF
--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -66,8 +66,6 @@ process STAR_ALIGN {
     decompress_cmd = ""
     def whitelistList = whitelist ? (whitelist instanceof List ? whitelist : [whitelist]) : []
 
-    println "Using whitelist files: ${whitelist}"
-
     if (whitelistList) {
         if (whitelistList.size() == 1) {
             def file = whitelistList[0]

--- a/modules/local/star_align/main.nf
+++ b/modules/local/star_align/main.nf
@@ -60,19 +60,38 @@ process STAR_ALIGN {
 
     // separate forward from reverse pairs
     def (forward, reverse) = reads.collate(2).transpose()
+
+    // parse whitelist file(s)
+    arg_whitelist = ""
+    decompress_cmd = ""
+    def whitelistList = whitelist ? (whitelist instanceof List ? whitelist : [whitelist]) : []
+
+    println "Using whitelist files: ${whitelist}"
+
+    if (whitelistList) {
+        if (whitelistList.size() == 1) {
+            def file = whitelistList[0]
+            def fileStr = file.toString()
+            if (fileStr.endsWith('.gz')) {
+                def uncompressed = file.getBaseName() // strips .gz
+                decompress_cmd = "gzip -cdf ${file} > ${uncompressed}"
+                arg_whitelist = "--soloCBwhitelist ${uncompressed}"
+            } else {
+                arg_whitelist = "--soloCBwhitelist ${fileStr}"
+            }
+        } else {
+            arg_whitelist = "--soloCBwhitelist ${whitelistList.join(' ')}"
+        }
+    }
     """
-    if [[ $whitelist == *.gz ]]; then
-        gzip -cdf $whitelist > whitelist.uncompressed.txt
-    else
-        cp $whitelist whitelist.uncompressed.txt
-    fi
+    ${decompress_cmd}
 
     STAR \\
         --genomeDir $index \\
         --readFilesIn ${reverse.join( "," )} ${forward.join( "," )} \\
         --runThreadN $task.cpus \\
         --outFileNamePrefix $prefix. \\
-        --soloCBwhitelist whitelist.uncompressed.txt \\
+        $arg_whitelist \\
         --soloType $protocol \\
         --soloFeatures $star_feature \\
         $other_10x_parameters \\

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -52,8 +52,7 @@
                     "type": "string",
                     "description": "If not using the 10X Genomics platform, a custom barcode whitelist can be used with `--barcode_whitelist`.",
                     "fa_icon": "fas fa-barcode",
-                    "format": "file-path",
-                    "exists": true
+                    "format": "file-path"
                 },
                 "aligner": {
                     "type": "string",

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -62,7 +62,10 @@ workflow SCRNASEQ {
     ch_txp2gene             = txp2gene         ? file(txp2gene, checkIfExists: true)         : []
 
     if (params.barcode_whitelist) {
-        ch_barcode_whitelist = file(params.barcode_whitelist, checkIfExists: true)
+        // if multiple files -> create channel with single list that keeps the order of the whitelist files preserved
+        ch_barcode_whitelist = params.barcode_whitelist.contains(',') ?
+            params.barcode_whitelist.split(',').collect { file(it.trim(), exists: true) } :
+            file(params.barcode_whitelist, checkIfExists: true)
     } else if (protocol_config.containsKey("whitelist")) {
         ch_barcode_whitelist = file("$projectDir/${protocol_config['whitelist']}", checkIfExists: true)
     } else {


### PR DESCRIPTION
This PR adds support for complex barcode configurations possible with `--soloType CB_UMI_Complex` in STAR, where multiple barcode segments can occur at different positions (e.g., `--soloCBposition 0_7_0_13 0_16_0_23`) with separate whitelist files (`--soloCBwhitelist whitelist1.txt whitelist2.txt`). See the [STAR manual](https://github.com/alexdobin/STAR/blob/master/doc/STARmanual.pdf) for reference.

Previously, the pipeline only accepted a single whitelist file (optionally gzipped). This PR allows passing multiple whitelist files via `params.barcode_whitelist` as a comma-separated list.

Additionally, this PR makes it possible to skip whitelist specification, which supports use cases where all barcodes should be accepted. Before, this caused a failure in [modules/local/star_align.nf#L64](https://github.com/nf-core/scrnaseq/blob/e0ddddbff9d8b8c2421c67ff07449a06f9ca02d2/modules/local/star_align.nf#L64C12-L64C21) due to `$whitelist` evaluating to an empty string and the bash code failing.