### PR TITLE
handle BOM files, update test to include BOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Features
 
 - Fix [#375](https://github.com/nf-core/scrnaseq/issues/375): mismatch between index and probeset when cellranger multi is used without a prebuilt index and an FFPE probeset is passed ([#502](https://github.com/nf-core/scrnaseq/pull/502))
+- Fix [#510](https://github.com/nf-core/scrnaseq/issues/510): Handle files with BOMs. ([#511](https://github.com/nf-core/scrnaseq/pull/511))
 
 ## v4.1.0 - 2025-08-01
 

--- a/assets/cellranger_barcodes_samplesheet.csv
+++ b/assets/cellranger_barcodes_samplesheet.csv
@@ -1,4 +1,4 @@
-sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,description
+﻿sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,description
 PBMC_10K_CMO,PBMC_10K_CMO_PBMCs_human_1,,CMO301,PBMCs_human_1
 PBMC_10K_CMO,PBMC_10K_CMO_PBMCs_human_2,,CMO302,PBMCs_human_2
 4PLEX_HUMAN,Liver_BC1,BC001,,Healthy liver dissociated using the Miltenyi FFPE Tissue Dissociation Kit

--- a/bin/check_cellrangermulti.py
+++ b/bin/check_cellrangermulti.py
@@ -17,7 +17,7 @@ def parse_samplesheet(samplesheet_path):
     os.makedirs(ocm_output_dir, exist_ok=True)
     os.makedirs(frna_output_dir, exist_ok=True)
 
-    with open(samplesheet_path) as csvfile:
+    with open(samplesheet_path, encoding="utf-8-sig") as csvfile:
         reader = csv.DictReader(csvfile)
         headers = reader.fieldnames
 


### PR DESCRIPTION
Closes #510, handles BOM characters at the beginnings of files.

https://stackoverflow.com/questions/68566490/should-i-use-utf8-or-utf-8-sig-when-opening-a-file-to-read-in-python

Using encoding "utf-8-sig" rather than "utf8" allows the BOM to be processed or ignores it if it is not present.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
