### PR TITLE
#512: Validate cellranger multi barcode sheet early

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fix [#375](https://github.com/nf-core/scrnaseq/issues/375): mismatch between index and probeset when cellranger multi is used without a prebuilt index and an FFPE probeset is passed ([#502](https://github.com/nf-core/scrnaseq/pull/502))
 - Fix [#510](https://github.com/nf-core/scrnaseq/issues/510): Handle files with BOMs. ([#511](https://github.com/nf-core/scrnaseq/pull/511))
+- Address [#512], adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 
 ## v4.1.0 - 2025-08-01
 

--- a/assets/cellranger_barcodes_test_duplicate_id.csv
+++ b/assets/cellranger_barcodes_test_duplicate_id.csv
@@ -1,0 +1,3 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,duplicate_id,BC001,,,First occurrence
+POOL_B,duplicate_id,BC002,,,Duplicate multiplexed_sample_id

--- a/assets/cellranger_barcodes_test_invalid_cmo.csv
+++ b/assets/cellranger_barcodes_test_invalid_cmo.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,sample_1,,CMO@301,,CMO ID with invalid character - invalid

--- a/assets/cellranger_barcodes_test_invalid_ocm.csv
+++ b/assets/cellranger_barcodes_test_invalid_ocm.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,sample_1,,,OB5,OCM ID with invalid value - must be OB1-OB4

--- a/assets/cellranger_barcodes_test_missing_barcode.csv
+++ b/assets/cellranger_barcodes_test_missing_barcode.csv
@@ -1,0 +1,4 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,sample_1,BC001,,,Valid row with probe barcode
+POOL_A,sample_2,,,,Row missing all barcodes
+POOL_A,sample_3,BC002,,,Valid row with probe barcode

--- a/assets/cellranger_barcodes_test_mixed_types.csv
+++ b/assets/cellranger_barcodes_test_mixed_types.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,sample_1,BC001,CMO301,,Row with both probe barcode AND CMO - invalid

--- a/assets/cellranger_barcodes_test_multiplexed_id_with_spaces.csv
+++ b/assets/cellranger_barcodes_test_multiplexed_id_with_spaces.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL_A,sample 1,BC001,,,Multiplexed sample ID with space - invalid

--- a/assets/cellranger_barcodes_test_sample_with_spaces.csv
+++ b/assets/cellranger_barcodes_test_sample_with_spaces.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+POOL A,sample_1,BC001,,,Sample name with space - invalid

--- a/assets/cellranger_barcodes_test_unknown_sample.csv
+++ b/assets/cellranger_barcodes_test_unknown_sample.csv
@@ -1,0 +1,2 @@
+sample,multiplexed_sample_id,probe_barcode_ids,cmo_ids,ocm_ids,description
+NONEXISTENT_SAMPLE,sample_1,BC001,,,Sample that does not exist in input samplesheet

--- a/assets/schema_cellranger_multi_barcodes.json
+++ b/assets/schema_cellranger_multi_barcodes.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://raw.githubusercontent.com/nf-core/scrnaseq/master/assets/schema_cellranger_multi_barcodes.json",
+    "title": "nf-core/scrnaseq pipeline - params.cellranger_multi_barcodes schema",
+    "description": "Schema for the file provided with params.cellranger_multi_barcodes",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "sample": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Sample name must be provided and cannot contain spaces"
+            },
+            "multiplexed_sample_id": {
+                "type": "string",
+                "pattern": "^\\S+$",
+                "errorMessage": "Multiplexed sample ID must be provided and cannot contain spaces"
+            },
+            "probe_barcode_ids": {
+                "type": "string",
+                "errorMessage": "Probe barcode IDs not identified"
+            },
+            "cmo_ids": {
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9_|-]*$",
+                "errorMessage": "CMO IDs may only contain alphanumeric, underscore, hyphen, and pipe characters"
+            },
+            "ocm_ids": {
+                "type": "string",
+                "pattern": "^(OB[1-4](\\|OB[1-4])*)?$",
+                "errorMessage": "OCM IDs must be OB1, OB2, OB3, or OB4 (or pipe-separated combinations)"
+            },
+            "description": {
+                "type": "string",
+                "errorMessage": "Description must be provided"
+            }
+        },
+        "required": ["sample", "multiplexed_sample_id", "description"]
+    },
+    "uniqueEntries": ["multiplexed_sample_id"]
+}

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -369,6 +369,7 @@
                     "type": "string",
                     "format": "file-path",
                     "exists": true,
+                    "schema": "assets/schema_cellranger_multi_barcodes.json",
                     "mimetype": "text/csv",
                     "description": "Additional samplesheet to provide information about multiplexed samples. See the 'Usage' section for more details."
                 }

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -239,16 +239,23 @@ def validateCellrangerMultiBarcodes() {
 
     cellranger_multi_barcodes = file(params.cellranger_multi_barcodes).splitCsv(header: true)
 
+    // Get unique samples from input samplesheet for cross-validation
+    def inputSamples = file(params.input).splitCsv(header: true).collect { it.sample }.toSet()
+
     // Check that at least one barcode column is provided for each row
     // and that each sample uses only one type of barcode
     def rowsWithoutBarcodes = []
     def sampleBarcodeTypes = [:]
+    def barcodeSamples = [] as Set
     cellranger_multi_barcodes.eachWithIndex { row, idx ->
         // print the row to debug logs for debugging
         log.debug "Row ${idx + 2}: ${row}"
 
         def sample = row.multiplexed_sample_id
         def rowNum = idx + 2 // +2 for 1-based indexing and header row
+
+        // Collect unique sample names for cross-validation
+        barcodeSamples << row.sample
 
         def barcodeTypes = []
         if (row.probe_barcode_ids) barcodeTypes << 'probe_barcode_ids'
@@ -261,13 +268,15 @@ def validateCellrangerMultiBarcodes() {
         sampleBarcodeTypes[sample] = [types: barcodeTypes.toSet(), row: rowNum]
     }
 
+    // Validate that at least one barcode identifier is populated in each row
     if (rowsWithoutBarcodes) {
         def errorDetails = rowsWithoutBarcodes.collect { "row ${it.row} (${it.sample})" }.join(', ')
         error("Please check cellranger_multi_barcodes samplesheet -> " +
               "The following rows have no barcode identifiers: ${errorDetails}. " +
-              "Each row must have at least one of: 'probe_barcode_ids', 'cmo_ids', or 'ocm_ids'.")
+              "Each row must have exactly one of: 'probe_barcode_ids', 'cmo_ids', or 'ocm_ids'.")
     }
 
+    // Validate that no more than one barcode identifier is populated in each row
     def samplesWithMixedBarcodes = sampleBarcodeTypes.findAll { sample, info -> info.types.size() > 1 }
     if (samplesWithMixedBarcodes) {
         def errorMsg = samplesWithMixedBarcodes.collect { sample, info ->
@@ -275,6 +284,14 @@ def validateCellrangerMultiBarcodes() {
         }.join('; ')
         error("Please check cellranger_multi_barcodes samplesheet -> " +
               "Each multiplexed_sample_id should use only one type of barcode identifier. ${errorMsg}")
+    }
+
+    // Validate that samples in cellranger_multi_barcodes exist in the input samplesheet
+    def unknownSamples = barcodeSamples - inputSamples
+    if (unknownSamples) {
+        error("Please check cellranger_multi_barcodes samplesheet -> " +
+              "The following sample(s) do not exist in the input samplesheet: ${unknownSamples.join(', ')}. " +
+              "The 'sample' column in cellranger_multi_barcodes must match 'sample' values in the input samplesheet.")
     }
 }
 

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -235,8 +235,6 @@ def validateInputParameters() {
 // Validate cellranger_multi_barcodes samplesheet for uniqueness and conditional requirements
 //
 def validateCellrangerMultiBarcodes() {
-    def barcodesFile = file(params.cellranger_multi_barcodes)
-
     cellranger_multi_barcodes = file(params.cellranger_multi_barcodes).splitCsv(header: true)
 
     // Get unique samples from input samplesheet for cross-validation
@@ -248,10 +246,7 @@ def validateCellrangerMultiBarcodes() {
     def sampleBarcodeTypes = [:]
     def barcodeSamples = [] as Set
     cellranger_multi_barcodes.eachWithIndex { row, idx ->
-        // print the row to debug logs for debugging
-        log.debug "Row ${idx + 2}: ${row}"
-
-        def sample = row.multiplexed_sample_id
+        def multiplexed_sample_id = row.multiplexed_sample_id
         def rowNum = idx + 2 // +2 for 1-based indexing and header row
 
         // Collect unique sample names for cross-validation
@@ -263,24 +258,24 @@ def validateCellrangerMultiBarcodes() {
         if (row.ocm_ids)           barcodeTypes << 'ocm_ids'
 
         if (barcodeTypes.isEmpty()) {
-            rowsWithoutBarcodes << [row: rowNum, sample: sample]
+            rowsWithoutBarcodes << [row: rowNum, multiplexed_sample_id: multiplexed_sample_id]
         }
-        sampleBarcodeTypes[sample] = [types: barcodeTypes.toSet(), row: rowNum]
+        sampleBarcodeTypes[multiplexed_sample_id] = [types: barcodeTypes.toSet(), row: rowNum]
     }
 
     // Validate that at least one barcode identifier is populated in each row
     if (rowsWithoutBarcodes) {
-        def errorDetails = rowsWithoutBarcodes.collect { "row ${it.row} (${it.sample})" }.join(', ')
+        def errorDetails = rowsWithoutBarcodes.collect { "row ${it.row} (${it.multiplexed_sample_id})" }.join(', ')
         error("Please check cellranger_multi_barcodes samplesheet -> " +
               "The following rows have no barcode identifiers: ${errorDetails}. " +
               "Each row must have exactly one of: 'probe_barcode_ids', 'cmo_ids', or 'ocm_ids'.")
     }
 
     // Validate that no more than one barcode identifier is populated in each row
-    def samplesWithMixedBarcodes = sampleBarcodeTypes.findAll { sample, info -> info.types.size() > 1 }
+    def samplesWithMixedBarcodes = sampleBarcodeTypes.findAll { multiplexed_sample_id, info -> info.types.size() > 1 }
     if (samplesWithMixedBarcodes) {
-        def errorMsg = samplesWithMixedBarcodes.collect { sample, info ->
-            "'${sample}' (row ${info.row}) uses multiple barcode types: ${info.types.join(', ')}"
+        def errorMsg = samplesWithMixedBarcodes.collect { multiplexed_sample_id, info ->
+            "'${multiplexed_sample_id}' (row ${info.row}) uses multiple barcode types: ${info.types.join(', ')}"
         }.join('; ')
         error("Please check cellranger_multi_barcodes samplesheet -> " +
               "Each multiplexed_sample_id should use only one type of barcode identifier. ${errorMsg}")

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -224,6 +224,58 @@ workflow PIPELINE_COMPLETION {
 //
 def validateInputParameters() {
     genomeExistsError()
+
+    // Validate cellranger_multi_barcodes if provided and aligner is cellrangermulti
+    if (params.aligner == 'cellrangermulti' && params.cellranger_multi_barcodes) {
+        validateCellrangerMultiBarcodes()
+    }
+}
+
+//
+// Validate cellranger_multi_barcodes samplesheet for uniqueness and conditional requirements
+//
+def validateCellrangerMultiBarcodes() {
+    def barcodesFile = file(params.cellranger_multi_barcodes)
+
+    cellranger_multi_barcodes = file(params.cellranger_multi_barcodes).splitCsv(header: true)
+
+    // Check that at least one barcode column is provided for each row
+    // and that each sample uses only one type of barcode
+    def rowsWithoutBarcodes = []
+    def sampleBarcodeTypes = [:]
+    cellranger_multi_barcodes.eachWithIndex { row, idx ->
+        // print the row to debug logs for debugging
+        log.debug "Row ${idx + 2}: ${row}"
+
+        def sample = row.multiplexed_sample_id
+        def rowNum = idx + 2 // +2 for 1-based indexing and header row
+
+        def barcodeTypes = []
+        if (row.probe_barcode_ids) barcodeTypes << 'probe_barcode_ids'
+        if (row.cmo_ids)           barcodeTypes << 'cmo_ids'
+        if (row.ocm_ids)           barcodeTypes << 'ocm_ids'
+
+        if (barcodeTypes.isEmpty()) {
+            rowsWithoutBarcodes << [row: rowNum, sample: sample]
+        }
+        sampleBarcodeTypes[sample] = [types: barcodeTypes.toSet(), row: rowNum]
+    }
+
+    if (rowsWithoutBarcodes) {
+        def errorDetails = rowsWithoutBarcodes.collect { "row ${it.row} (${it.sample})" }.join(', ')
+        error("Please check cellranger_multi_barcodes samplesheet -> " +
+              "The following rows have no barcode identifiers: ${errorDetails}. " +
+              "Each row must have at least one of: 'probe_barcode_ids', 'cmo_ids', or 'ocm_ids'.")
+    }
+
+    def samplesWithMixedBarcodes = sampleBarcodeTypes.findAll { sample, info -> info.types.size() > 1 }
+    if (samplesWithMixedBarcodes) {
+        def errorMsg = samplesWithMixedBarcodes.collect { sample, info ->
+            "'${sample}' (row ${info.row}) uses multiple barcode types: ${info.types.join(', ')}"
+        }.join('; ')
+        error("Please check cellranger_multi_barcodes samplesheet -> " +
+              "Each multiplexed_sample_id should use only one type of barcode identifier. ${errorMsg}")
+    }
 }
 
 //

--- a/tests/main_pipeline_cellrangermulti.nf.test
+++ b/tests/main_pipeline_cellrangermulti.nf.test
@@ -266,5 +266,193 @@ nextflow_workflow {
         }
     }
 
+    test("test-dataset_cellrangermulti_barcodes_sample_with_spaces") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
 
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_sample_spaces"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_sample_with_spaces.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stderr.any { it.contains("sample") && it.contains("cannot contain spaces") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_multiplexed_id_with_spaces") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_multiplexed_id_spaces"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_multiplexed_id_with_spaces.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stderr.any { it.contains("multiplexed_sample_id") && it.contains("cannot contain spaces") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_invalid_cmo") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_invalid_cmo"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_invalid_cmo.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stderr.any { it.contains("cmo_ids") && it.contains("alphanumeric") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_invalid_ocm") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_invalid_ocm"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_invalid_ocm.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stderr.any { it.contains("ocm_ids") && it.contains("OB1") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_unknown_sample") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_unknown_sample"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_unknown_sample.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stdout.any { it.contains("do not exist in the input samplesheet") && it.contains("NONEXISTENT_SAMPLE") } }
+            )
+        }
+    }
 }

--- a/tests/main_pipeline_cellrangermulti.nf.test
+++ b/tests/main_pipeline_cellrangermulti.nf.test
@@ -113,6 +113,9 @@ nextflow_pipeline {
     }
 
     test("test-dataset_cellrangermulti_mismatched_gex_reference") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "human"
 
         when {
             params {
@@ -136,6 +139,129 @@ nextflow_pipeline {
                 {assert !workflow.success},
                 {assert workflow.failed},
                 {assert workflow.stdout.any { it.contains("Parameter 'gex_reference_version' (GRCm39) does not match the probeset reference genome (GRCh38)") } }
+            )
+        }
+    }
+}
+
+nextflow_workflow {
+
+    name "Test PIPELINE_INITIALISATION for cellranger multi"
+    script "subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf"
+    workflow "PIPELINE_INITIALISATION"
+
+    test("test-dataset_cellrangermulti_barcodes_missing_barcode") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_missing_barcode"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_missing_barcode.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stdout.any { it.contains("The following rows have no barcode identifiers") } },
+                { assert workflow.stdout.any { it.contains("row 3 (sample_2)") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_mixed_types") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_mixed_types"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_mixed_types.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stdout.any { it.contains("Each multiplexed_sample_id should use only one type of barcode identifier") } },
+                { assert workflow.stdout.any { it.contains("sample_1") } }
+            )
+        }
+    }
+
+    test("test-dataset_cellrangermulti_barcodes_duplicate_id") {
+        tag "validation"
+        tag "cellranger/multi"
+        tag "initialisation"
+
+        when {
+            params {
+                aligner                   = 'cellrangermulti'
+                outdir                    = "${outputDir}/results_cellrangermulti_duplicate_id"
+                input                     = "${baseDir}/assets/cellrangermulti_samplesheet.csv"
+                cellranger_multi_barcodes = "${baseDir}/assets/cellranger_barcodes_test_duplicate_id.csv"
+                protocol                  = 'auto'
+                skip_cellbender           = true
+            }
+            workflow {
+                """
+                input[0] = false  // version
+                input[1] = true   // validate_params
+                input[2] = false  // monochrome_logs
+                input[3] = []     // nextflow_cli_args
+                input[4] = params.outdir
+                input[5] = params.input
+                input[6] = false  // help
+                input[7] = false  // help_full
+                input[8] = false  // show_hidden
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert !workflow.success },
+                { assert workflow.failed },
+                { assert workflow.stderr.any { it.contains("Entry 2") && it.contains("Detected duplicate entries") && it.contains("multiplexed_sample_id:duplicate_id") } }
             )
         }
     }


### PR DESCRIPTION
This PR frontloads some of the cellranger multi barcode sheet validation to avoid long run times that end in failure and to try to avoid unclear errors. The following are implemented

* A new `schema_cellranger_multi_barcodes.json` file which leverages nf-schema to enforce uniqueness on the `multiplexed_sample_id` column and enforce some common-sense or cellranger-specified pattern restrictions for the sheet fields
* Groovy logic to ensure `sample` values in the barcode sheet match `sample` values in the input samplesheet
* Groovy logic to ensure that each row in the barcode sheet has exactly one barcode ID field populated
* Tests for all of the breaking cases
* Updated usage instructions to be more explicit about these requirements

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] `CHANGELOG.md` is updated.
