### PR TITLE
Improve modules.config structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix [#510](https://github.com/nf-core/scrnaseq/issues/510): Handle files with BOMs. ([#511](https://github.com/nf-core/scrnaseq/pull/511))
 - Address [#512], adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 
+## Fixes
+
+- Fix `modules.config` structure to make sure all ways of providing the `aligner` param work ([514](https://github.com/nf-core/scrnaseq/pull/514))
+
 ## v4.1.0 - 2025-08-01
 
 ### Features

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,6 +19,7 @@ process {
 
     withName: FASTQC {
         ext.args = '--quiet'
+        ext.prefix = { (params.aligner == "cellrangermulti") ? "${meta.id}_${meta.feature_type}" : "${meta.id}" } 
         time   = { 120.h  * task.attempt }
     }
 
@@ -31,24 +32,23 @@ process {
         ]
     }
 
-    if (!params.skip_cellbender) {
-        withName: 'CELLBENDER_REMOVEBACKGROUND' {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/${meta.id}/cellbender_removebackground" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
-        withName: 'ANNDATA_BARCODES' {
-            ext.prefix = { "${meta.id}_${meta.input_type}_matrix" }
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/mtx_conversions/${meta.id}" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
+    withName: 'CELLBENDER_REMOVEBACKGROUND' {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/${meta.id}/cellbender_removebackground" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 
+    withName: 'ANNDATA_BARCODES' {
+        ext.prefix = { "${meta.id}_${meta.input_type}_matrix" }
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/mtx_conversions/${meta.id}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+    
     withName: 'MTX_TO_H5AD|CONCAT_H5AD|ANNDATAR_CONVERT' {
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/mtx_conversions" },
@@ -69,190 +69,147 @@ process {
             enabled: false
         ]
     }
-}
 
-if(params.aligner == "cellranger") {
-    process {
-        withName: CELLRANGER_MKGTF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkgtf",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            ext.args = "--attribute=gene_biotype:protein_coding --attribute=gene_biotype:lncRNA --attribute=gene_biotype:pseudogene"
-        }
-        withName: CELLRANGER_MKREF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkref",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
-        withName: CELLRANGER_COUNT {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/count",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            ext.args = {"--chemistry ${meta.chemistry} --create-bam ${params.save_align_intermeds}" + " " + (meta.expected_cells ? "--expect-cells ${meta.expected_cells}" : '')}
-            time   = { 240.h * task.attempt }
-        }
+    withName: CELLRANGER_MKGTF {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/mkgtf",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = "--attribute=gene_biotype:protein_coding --attribute=gene_biotype:lncRNA --attribute=gene_biotype:pseudogene"
     }
-}
 
-if(params.aligner == "cellrangerarc") {
-    process {
-        withName: CELLRANGERARC_MKGTF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkgtf",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            ext.args = "--attribute=gene_biotype:protein_coding --attribute=gene_biotype:lncRNA --attribute=gene_biotype:pseudogene"
-        }
-        withName: CELLRANGERARC_MKREF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkref",
-                mode: params.publish_dir_mode
-            ]
-        }
-        withName: CELLRANGERARC_COUNT {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/count",
-                mode: params.publish_dir_mode
-            ]
-            ext.args = {meta.expected_cells ? "--expect-cells ${meta.expected_cells}" : ''}
-            time   = { 240.h * task.attempt }
-        }
+    withName: CELLRANGER_MKREF {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/mkref",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
-}
 
-if ( params.aligner == "simpleaf" ) {
-    process {
-        withName: 'SIMPLEAF_INDEX' {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}" },
-                mode: params.publish_dir_mode,
-                enabled: params.save_reference,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            ext.prefix = { "simpleaf_index" }
-
-        }
-        withName: 'SIMPLEAF_QUANT' {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/${meta.id}" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> (filename.contains('af_map') && !params.save_align_intermeds) || filename.equals('versions.yml') ? null :  filename }
-            ]
-            ext.prefix = { "simpleaf_quant" }
-
-        }
-        // Fix for issue 196
-        // Modified for issue 334
-        withName: 'ALEVINQC' {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/${meta.id}" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            time = { 120.h }
-        }
+    withName: CELLRANGER_COUNT {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/count",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = {"--chemistry ${meta.chemistry} --create-bam ${params.save_align_intermeds}" + " " + (meta.expected_cells ? "--expect-cells ${meta.expected_cells}" : '')}
+        time   = { 240.h * task.attempt }
     }
-}
 
-if (params.aligner == "star") {
-    process {
-        withName: STAR_ALIGN {
-            ext.args = { "--readFilesCommand zcat --runDirPerm All_RWX --outWigType bedGraph --twopassMode Basic --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM ${task.memory.toBytes()}" }
-        }
-        withName: STAR_GENOMEGENERATE {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}/genome_generate" },
-                mode: params.publish_dir_mode,
-                enabled: params.save_reference,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
-
-        if(params.save_align_intermeds) {
-            withName: 'STAR_ALIGN' {
-                publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/${meta.id}" },
-                    mode: params.publish_dir_mode
-                ]
-            }
-        }
-        else {
-            withName: 'STAR_ALIGN' {
-                publishDir = [
-                    path: { "${params.outdir}/${params.aligner}/${meta.id}" },
-                    mode: params.publish_dir_mode,
-                    pattern: '*',
-                    saveAs: { it.endsWith('.bam') ? null : it }
-                ]
-            }
-        }
+    withName: CELLRANGERARC_MKGTF {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/mkgtf",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = "--attribute=gene_biotype:protein_coding --attribute=gene_biotype:lncRNA --attribute=gene_biotype:pseudogene"
     }
-}
 
-if (params.aligner == 'kallisto') {
-    process {
-        withName: KALLISTOBUSTOOLS_REF {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}" },
-                mode: params.publish_dir_mode,
-                enabled: params.save_reference,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
-        withName: KALLISTOBUSTOOLS_COUNT {
-            publishDir = [
-                path: { "${params.outdir}/${params.aligner}" },
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-            ext.args = "--workflow ${params.kb_workflow} --filter"
-        }
+    withName: CELLRANGERARC_MKREF {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/mkref",
+            mode: params.publish_dir_mode
+        ]
     }
-}
 
-if (params.aligner == 'cellrangermulti') {
-    process {
-        withName: FASTQC { ext.prefix = { "${meta.id}_${meta.feature_type}" } } // allow distinguishment of data types after renaming
-        withName: 'NFCORE_SCRNASEQ:SCRNASEQ:CELLRANGER_MULTI_ALIGN:CELLRANGER_MULTI' {
-            beforeScript = 'export TENX_DISABLE_TELEMETRY=1'
-            ext.prefix = null // force it null, for some reason it was being wrongly read in the module
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/count",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> ( filename.equals('versions.yml') || filename.equals('cellranger_multi_config.csv') ) ? null : filename }
-            ]
-        }
-        withName: 'GUNZIP*' {
-            publishDir = [
-                enabled: false
-            ]
-        }
-        withName: CELLRANGER_MKGTF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkgtf",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
-        withName: CELLRANGER_MKREF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkref",
-                mode: params.publish_dir_mode
-            ]
-        }
-        withName: CELLRANGER_MKVDJREF {
-            publishDir = [
-                path: "${params.outdir}/${params.aligner}/mkvdjref",
-                mode: params.publish_dir_mode,
-                saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-            ]
-        }
+    withName: CELLRANGERARC_COUNT {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/count",
+            mode: params.publish_dir_mode
+        ]
+        ext.args = {meta.expected_cells ? "--expect-cells ${meta.expected_cells}" : ''}
+        time   = { 240.h * task.attempt }
+    }
+
+    withName: 'SIMPLEAF_INDEX' {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_reference,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.prefix = { "simpleaf_index" }
+    }
+
+    withName: 'SIMPLEAF_QUANT' {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/${meta.id}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> (filename.contains('af_map') && !params.save_align_intermeds) || filename.equals('versions.yml') ? null :  filename }
+        ]
+        ext.prefix = { "simpleaf_quant" }
+    }
+
+    // Fix for issue 196
+    // Modified for issue 334
+    withName: 'ALEVINQC' {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/${meta.id}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        time = { 120.h }
+    }
+
+    withName: STAR_ALIGN {
+        ext.args = { "--readFilesCommand zcat --runDirPerm All_RWX --outWigType bedGraph --twopassMode Basic --outSAMtype BAM SortedByCoordinate --limitBAMsortRAM ${task.memory.toBytes()}" }
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/${meta.id}" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_align_intermeds,
+            saveAs: { it.endsWith('.bam') ? null : it }
+        ]
+    }
+
+    withName: STAR_GENOMEGENERATE {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}/genome_generate" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_reference,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: KALLISTOBUSTOOLS_REF {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_reference,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+    }
+
+    withName: KALLISTOBUSTOOLS_COUNT {
+        publishDir = [
+            path: { "${params.outdir}/${params.aligner}" },
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
+        ext.args = "--workflow ${params.kb_workflow} --filter"
+    }
+
+    withName: CELLRANGER_MULTI {
+        beforeScript = 'export TENX_DISABLE_TELEMETRY=1'
+        ext.prefix = null // force it null, for some reason it was being wrongly read in the module
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/count",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> ( filename.equals('versions.yml') || filename.equals('cellranger_multi_config.csv') ) ? null : filename }
+        ]
+    }
+
+    withName: 'GUNZIP*' {
+        publishDir = [
+            enabled: false
+        ]
+    }
+
+    withName: CELLRANGER_MKVDJREF {
+        publishDir = [
+            path: "${params.outdir}/${params.aligner}/mkvdjref",
+            mode: params.publish_dir_mode,
+            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        ]
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -157,8 +157,7 @@ process {
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/${meta.id}" },
             mode: params.publish_dir_mode,
-            enabled: params.save_align_intermeds,
-            saveAs: { it.endsWith('.bam') ? null : it }
+            saveAs: { (!it.endsWith('.bam') || params.save_align_intermeds) ? it : null }
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -19,7 +19,7 @@ process {
 
     withName: FASTQC {
         ext.args = '--quiet'
-        ext.prefix = { (params.aligner == "cellrangermulti") ? "${meta.id}_${meta.feature_type}" : "${meta.id}" } 
+        ext.prefix = { (params.aligner == "cellrangermulti") ? "${meta.id}_${meta.feature_type}" : "${meta.id}" }
         time   = { 120.h  * task.attempt }
     }
 
@@ -48,7 +48,7 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
     }
-    
+
     withName: 'MTX_TO_H5AD|CONCAT_H5AD|ANNDATAR_CONVERT' {
         publishDir = [
             path: { "${params.outdir}/${params.aligner}/mtx_conversions" },

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,7 +15,7 @@ config {
     profile "test"
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'conf/modules.config', 'tests/nextflow.config', 'tests/.nftignore'
 
     // load the necessary plugins
     plugins {

--- a/nf-test.config
+++ b/nf-test.config
@@ -15,7 +15,7 @@ config {
     profile "test"
 
     // list of filenames or patterns that should be trigger a full test run
-    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'conf/modules.config', 'tests/nextflow.config', 'tests/.nftignore'
+    triggers 'nextflow.config', 'nf-test.config', 'conf/test.config', 'tests/nextflow.config', 'tests/.nftignore'
 
     // load the necessary plugins
     plugins {


### PR DESCRIPTION
Previously, we had the following structure in `modules.config`:

```
if (params.aligner == 'cellranger') {
    process {
        withName: <name>: {
            ...
        }
    }
}
```

I recently noticed that this leads to problems. Nextflow allows setting parameters via CLI (e.g. `--aligner`) but also to set them via config files (e.g. `nextflow.config`) in the launch dir. I mostly use config files.

Now the above syntax only works if the `aligner` parameter is provided via the CLI. Apparently, the if clause is evaluated before the config files (including the default `nextflow.config` that ships with the pipeline) are processed.

You can test this most easily by introducing a syntax error into the body of the if-clause and trying to run the pipeline with different ways of setting the `aligner` parameter. You will notice the config evaluation only fails if you provide `--aligner cellranger` via CLI. In all other cases, the body of the if clause will not be evaluated.

---

I think it would work if we would move the if clauses _inside_ the `process` block, but actually the if clauses are not needed at all. 
I think some time ago, nextflow warned if there were `withName` tags that did not match any process at runtime. This is most likely why this structure was introduced in the first place. Nowadays, nextflow does not complain if there are unmatched `withName` tags at runtime, but rather `nf-core/tools` checks if everything is correct during pipeline linting.

You can have a look at my changes; I removed the if clauses almost entirely while keeping the `modules.config` functionally equal