### PR TITLE
515: Fix bug processing singleplex flex data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixes
 
 - Fix `modules.config` structure to make sure all ways of providing the `aligner` param work ([514](https://github.com/nf-core/scrnaseq/pull/514))
+- Fix [515](https://github.com/nf-core/scrnaseq/issues/515), failure when running singleplex flex data by updating cellranger multi module ([517](https://github.com/nf-core/scrnaseq/pull/517))
 
 ## v4.1.0 - 2025-08-01
 

--- a/modules.json
+++ b/modules.json
@@ -37,7 +37,7 @@
                     },
                     "cellranger/multi": {
                         "branch": "master",
-                        "git_sha": "a772a68aab0866ed10a020443beaedd987d8d690",
+                        "git_sha": "2501026a8888cac0d2ddac55207a7fdae0ef1f0f",
                         "installed_by": ["modules"]
                     },
                     "cellrangerarc/count": {

--- a/modules/nf-core/cellranger/multi/main.nf
+++ b/modules/nf-core/cellranger/multi/main.nf
@@ -76,7 +76,7 @@ process CELLRANGER_MULTI {
     target_panel = gex_targetpanel_name != '' ? "target-panel,./$gex_targetpanel_name" : ''
 
     // fixed RNA reference (not sample info!) also goes under GEX section
-    frna_probeset = include_frna && gex_frna_probeset_name != '' ? "probe-set,./$gex_frna_probeset_name" : ''
+    frna_probeset = gex_frna_probeset_name != '' ? "probe-set,./$gex_frna_probeset_name" : ''
 
     // VDJ inner primer set
     primer_index = vdj_primer_index ? "inner-enrichment-primers,./references/primers/${vdj_primer_index.getName()}" : ''

--- a/modules/nf-core/cellranger/multi/tests/main.nf.test
+++ b/modules/nf-core/cellranger/multi/tests/main.nf.test
@@ -877,5 +877,115 @@ nextflow_process {
         }
 
     }
+    test("cellranger - multi - 10k - kidney - flex - singleplex") {
 
+        when {
+            process {
+                """
+                //
+                // preparation: unfortunately have to repeat data load
+                //
+
+                /***************************/
+                /*** stage 10k Kidney data ***/
+                /***************************/
+
+                // stage FASTQ test data
+                fastqs = [
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/10xgenomics/cellranger/singleplex_flex/Human_Kidney_GEM-X_Flex_S1_L001_R1_001.subsampled.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/10xgenomics/cellranger/singleplex_flex/Human_Kidney_GEM-X_Flex_S1_L001_R2_001.subsampled.fastq.gz', checkIfExists: true)
+                ]
+                def fastq_samplename_10k_kidney = "subsampled_10k_human_kidney_gemx_flex"
+
+                /*******************************/
+                /*** end stage 10k Kidney data ***/
+                /*******************************/
+
+                /***************************/
+                /*** stage GEX reference ***/
+                /***************************/
+
+                // will build this as done in cellranger count test
+                gex_ref_fasta    = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true)
+                gex_ref_gtf      = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true)
+                def gex_ref_name = "homo_sapiens_chr22_reference"
+
+                /*******************************/
+                /*** end stage GEX reference ***/
+                /*******************************/
+
+                probeset = file(params.modules_testdata_base_path + 'genomics/homo_sapiens/10xgenomics/cellranger/references/flex/Chromium_Human_Transcriptome_Probe_Set_v1.1.0_GRCh38-2024-A.chr22.csv', checkIfExists: true)
+
+                // make an empty dummy file, for FASTQs
+                empty_file = file("$workDir/EMPTY")
+                empty_file.append("")
+
+
+                // create empty channels to fill unused cellranger multi arguments
+                // fastqs need a [ meta, ref ] structure
+                // references just need a path
+                ch_gex_fastqs            = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_vdj_fastqs            = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_ab_fastqs             = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_beam_fastqs           = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_cmo_fastqs            = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_crispr_fastqs         = Channel.value( [ [ id:"EMPTY", options:[] ], empty_file ] )
+                ch_gex_frna_probeset     = []
+                ch_gex_targetpanel       = []
+                ch_vdj_reference         = []
+                ch_vdj_primer_index      = []
+                ch_fb_reference          = []
+                ch_beam_antigen_panel    = []
+                ch_beam_control_panel    = []
+                ch_cmo_reference         = []
+                ch_cmo_barcodes          = []
+                ch_ocm_barcodes          = []
+                ch_cmo_sample_assignment = []
+                ch_frna_sampleinfo       = []
+
+                // collect references and fastq files for staging
+                ch_gex_fastqs_10k_kidney = Channel.of( fastqs )
+                    .collect()
+                    .map { reads -> [ [ id:fastq_samplename_10k_kidney , options:[ "create-bam":false ] ], reads ] }
+
+                input[0]  = [ id:'subsampled_10k_human_kidney_gemx_flex', single_end:false ]
+                input[1]  = ch_gex_fastqs_10k_kidney
+                input[2]  = ch_vdj_fastqs
+                input[3]  = ch_ab_fastqs
+                input[4]  = ch_beam_fastqs
+                input[5]  = ch_cmo_fastqs
+                input[6]  = ch_crispr_fastqs
+                input[7]  = CELLRANGER_MKREF.out.reference
+                input[8]  = probeset
+                input[9]  = ch_gex_targetpanel
+                input[10] = ch_vdj_reference
+                input[11] = ch_vdj_primer_index
+                input[12] = ch_fb_reference
+                input[13] = ch_beam_antigen_panel
+                input[14] = ch_beam_control_panel
+                input[15] = ch_cmo_reference
+                input[16] = ch_cmo_barcodes
+                input[17] = ch_cmo_sample_assignment
+                input[18] = ch_frna_sampleinfo
+                input[19] = ch_ocm_barcodes
+                input[20] = false // default to false to guarantee renaming during test
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.outs[0][1].findAll {  file(it).name == 'metrics_summary.csv'  },
+                    process.out.outs[0][1].findAll {  file(it).name == 'filtered_feature_bc_matrix.h5'  },
+                    process.out.outs[0][1].findAll {  file(it).name == 'raw_feature_bc_matrix.h5' },
+                    process.out.outs[0][1].findAll {  file(it).name == 'sample_filtered_feature_bc_matrix.h5' },
+                    process.out.outs[0][1].findAll {  file(it).name == 'sample_raw_feature_bc_matrix.h5' }
+                ).match() },
+                { assert snapshot(process.out.versions).match("versions-flex-singleplex") }
+            )
+        }
+
+    }
 }

--- a/modules/nf-core/cellranger/multi/tests/main.nf.test.snap
+++ b/modules/nf-core/cellranger/multi/tests/main.nf.test.snap
@@ -1,4 +1,16 @@
 {
+    "versions-flex-singleplex": {
+        "content": [
+            [
+                "versions.yml:md5,1e16f7d40ef563f7d0a24f8944374d4d"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-01-14T17:24:23.520285805"
+    },
     "cellranger - multi - 10k - PBMC": {
         "content": [
             [
@@ -68,6 +80,30 @@
             "nextflow": "25.04.0"
         },
         "timestamp": "2025-11-17T16:09:13.334801399"
+    },
+    "cellranger - multi - 10k - kidney - flex - singleplex": {
+        "content": [
+            [
+                "metrics_summary.csv:md5,065d5fa688d8a27d2fa25a8e0f03670d"
+            ],
+            [
+                "filtered_feature_bc_matrix.h5:md5,9dd51a9b7bcbed4e33fca2fd912894b1"
+            ],
+            [
+                "raw_feature_bc_matrix.h5:md5,3a9537d19966914ed90da35c9c5fe455"
+            ],
+            [
+                "sample_filtered_feature_bc_matrix.h5:md5,12f93947e14929d7a5c4ba340e4aa81c"
+            ],
+            [
+                "sample_raw_feature_bc_matrix.h5:md5,45c0a4f2907c78b3aca295d0623e2163"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.04.8"
+        },
+        "timestamp": "2026-01-20T15:47:56.204324736"
     },
     "versions-with-cmo": {
         "content": [


### PR DESCRIPTION
This closes #515, in which singleplex flex data could not be processed because the probe barcode file was not passed. The cellranger multi module is updated to include the fix implemented in: https://github.com/nf-core/modules/pull/9652

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.
