### PR TITLE
Use genome config for prebuilt indexes

### DIFF
--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -47,12 +47,18 @@ workflow SCRNASEQ {
     qcatch_config = params.aligner == "simpleaf" ? Utils.getProtocol(workflow, log, "qcatch", params.protocol) : [:]
     qcatch_chemistry = qcatch_config.containsKey('protocol') ? qcatch_config['protocol'] : null
 
+    genome_txp2gene = getGenomeAttribute('txp2gene')
+    genome_kallisto_index = getGenomeAttribute('kallisto')
+    genome_simpleaf_index = getGenomeAttribute('simpleaf')
+    genome_cellranger_index = params.aligner in ["cellranger", "cellrangermulti"] ? getGenomeAttribute('cellranger') : null
+    genome_cellranger_index = params.aligner == "cellrangerarc" ? getGenomeAttribute('cellrangerarc') : genome_cellranger_index
+
     // general input and params
     ch_genome_fasta         = params.fasta                ? file(params.fasta, checkIfExists: true)    : []
     ch_gtf                  = params.gtf                  ? file(params.gtf, checkIfExists: true)      : []
     ch_transcript_fasta     = params.transcript_fasta     ? file(params.transcript_fasta)              : []
     ch_motifs               = params.motifs               ? file(params.motifs)                        : []
-    ch_txp2gene             = params.txp2gene             ? file(params.txp2gene, checkIfExists: true) : []
+    ch_txp2gene             = params.txp2gene             ? file(params.txp2gene, checkIfExists: true) : genome_txp2gene ? file(genome_txp2gene, checkIfExists: true) : []
 
     if (params.barcode_whitelist) {
         ch_barcode_whitelist = file(params.barcode_whitelist, checkIfExists: true)
@@ -67,19 +73,19 @@ workflow SCRNASEQ {
     ch_input = file(params.input)
 
     //kallisto params
-    ch_kallisto_index = params.kallisto_index ? file(params.kallisto_index, checkIfExists: true) : []
+    ch_kallisto_index = params.kallisto_index ? file(params.kallisto_index, checkIfExists: true) : genome_kallisto_index ? file(genome_kallisto_index, checkIfExists: true) : []
     kb_t1c            = params.kb_t1c         ? file(params.kb_t1c, checkIfExists: true) : []
     kb_t2c            = params.kb_t2c         ? file(params.kb_t2c, checkIfExists: true) : []
 
     //simpleaf params
-    ch_simpleaf_index   = params.simpleaf_index ? file(params.simpleaf_index, checkIfExists: true) : []
+    ch_simpleaf_index   = params.simpleaf_index ? file(params.simpleaf_index, checkIfExists: true) : genome_simpleaf_index ? file(genome_simpleaf_index, checkIfExists: true) : []
 
     //star params
     star_index        = params.star_index ? file(params.star_index, checkIfExists: true) : null
     ch_star_index     = star_index ? channel.value( [[id: star_index.baseName], star_index] ) : []
 
     //cellranger params
-    ch_cellranger_index = params.cellranger_index ? file(params.cellranger_index, checkIfExists: true) : []
+    ch_cellranger_index = params.cellranger_index ? file(params.cellranger_index, checkIfExists: true) : genome_cellranger_index ? file(genome_cellranger_index, checkIfExists: true) : []
 
     //cellrangermulti params
     cellranger_vdj_index = params.cellranger_vdj_index      ? file(params.cellranger_vdj_index, checkIfExists: true)      : []


### PR DESCRIPTION
## Description

Addresses #393.

This wires custom genome attributes into the existing prebuilt-index inputs used by the workflow:

- `simpleaf` -> `simpleaf_index`
- `kallisto` -> `kallisto_index`
- `txp2gene` -> `txp2gene`
- `cellranger` -> `cellranger_index` for Cell Ranger / Cell Ranger Multi
- `cellrangerarc` -> `cellranger_index` for Cell Ranger ARC

Explicit CLI / params-file values still take precedence over genome-config attributes.

## Validation

- [x] `git diff --check`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow run . --help -ansi-log false`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow -c /tmp/scrnaseq-igenomes-index-only.config run . -preview -ansi-log false --aligner kallisto --outdir /tmp/scrnaseq-index-validation/kallisto-preview`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow -log /tmp/scrnaseq-simpleaf-preview.log -c /tmp/scrnaseq-igenomes-index-only.config run . -preview -ansi-log false -work-dir /tmp/scrnaseq-index-validation/simpleaf-work --aligner simpleaf --outdir /tmp/scrnaseq-index-validation/simpleaf-preview`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow -log /tmp/scrnaseq-cellranger-preview.log -c /tmp/scrnaseq-igenomes-index-only.config run . -preview -ansi-log false -work-dir /tmp/scrnaseq-index-validation/cellranger-work --aligner cellranger --outdir /tmp/scrnaseq-index-validation/cellranger-preview`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow -log /tmp/scrnaseq-cellrangerarc-preview.log -c /tmp/scrnaseq-igenomes-index-only.config run . -preview -ansi-log false -work-dir /tmp/scrnaseq-index-validation/cellrangerarc-work --aligner cellrangerarc --outdir /tmp/scrnaseq-index-validation/cellrangerarc-preview`
- [x] `JAVA_HOME=/opt/homebrew/opt/openjdk@21/libexec/openjdk.jdk/Contents/Home PATH=/opt/homebrew/opt/openjdk@21/bin:$PATH ./nextflow -log /tmp/scrnaseq-lint.log lint .` - exit 0; reported existing warnings, no errors.

Not run locally:

- [ ] `nf-core pipelines lint .` - `nf-core` is not installed in this environment.
- [ ] `nf-test test --tag test --profile +docker --verbose` - `nf-test` is not installed in this environment.
- [ ] Full Docker profile pipeline tests.

## Notes

No docs, schema, changelog, output docs, or citations were updated because this does not add parameters, outputs, tools, or user-facing command syntax.
