### PR TITLE
Fix genome handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixes
 
+- Fix [#539](https://github.com/nf-core/scrnaseq/issues/539) and [#393](https://github.com/nf-core/scrnaseq/issues/393): genome and aligner index parameter handling by resolving iGenomes attributes in the entry workflow and passing reference paths explicitly into `SCRNASEQ`, restoring configurable pre-built indexes via custom `igenomes` configs (reverts [#483](https://github.com/nf-core/scrnaseq/pull/483) pipeline-wide params approach) ([#545](https://github.com/nf-core/scrnaseq/pull/545))
 - Fix `modules.config` structure to make sure all ways of providing the `aligner` param work ([514](https://github.com/nf-core/scrnaseq/pull/514))
 - Fix [515](https://github.com/nf-core/scrnaseq/issues/515), failure when running singleplex flex data by updating cellranger multi module ([517](https://github.com/nf-core/scrnaseq/pull/517))
 - Fix [522](https://github.com/nf-core/scrnaseq/issues/522), protocol not being passed correctly when running cellranger multi ([524](https://github.com/nf-core/scrnaseq/pull/524))

--- a/main.nf
+++ b/main.nf
@@ -55,7 +55,21 @@ params.cellranger_vdj_index = getGenomeAttribute('cellranger_vdj')
 workflow NFCORE_SCRNASEQ {
 
     take:
-    samplesheet // channel: samplesheet read in from --input
+    samplesheet                  // channel: samplesheet read in from --input
+    fasta                        // val: path-like string (or null)
+    gtf                          // val: path-like string (or null)
+    star_index                   // val: path-like string (or null)
+    simpleaf_index               // val: path-like string (or null)
+    kallisto_index               // val: path-like string (or null)
+    cellranger_index             // val: path-like string (or null)
+    txp2gene                     // val: path-like string (or null)
+    transcript_fasta             // val: path-like string (or null)
+    motifs                       // val: path-like string (or null)
+    cellranger_vdj_index         // val: path-like string (or null)
+    multiqc_config               // val: path-like string (or null)
+    multiqc_logo                 // val: path-like string (or null)
+    multiqc_methods_description  // val: path-like string (or null)
+    outdir                       // val: string
 
     main:
 
@@ -64,20 +78,20 @@ workflow NFCORE_SCRNASEQ {
     //
     SCRNASEQ (
         samplesheet,
-        params.fasta,
-        params.gtf,
-        params.star_index,
-        params.simpleaf_index,
-        params.kallisto_index,
-        params.cellranger_index,
-        params.txp2gene,
-        params.transcript_fasta,
-        params.motifs,
-        params.cellranger_vdj_index,
-        params.multiqc_config,
-        params.multiqc_logo,
-        params.multiqc_methods_description,
-        params.outdir,
+        fasta,
+        gtf,
+        star_index,
+        simpleaf_index,
+        kallisto_index,
+        cellranger_index,
+        txp2gene,
+        transcript_fasta,
+        motifs,
+        cellranger_vdj_index,
+        multiqc_config,
+        multiqc_logo,
+        multiqc_methods_description,
+        outdir,
     )
     emit:
     multiqc_report = SCRNASEQ.out.multiqc_report // channel: /path/to/multiqc_report.html
@@ -111,6 +125,20 @@ workflow {
     //
     NFCORE_SCRNASEQ (
         PIPELINE_INITIALISATION.out.samplesheet,
+        params.fasta,
+        params.gtf,
+        params.star_index,
+        params.simpleaf_index,
+        params.kallisto_index,
+        params.cellranger_index,
+        params.txp2gene,
+        params.transcript_fasta,
+        params.motifs,
+        params.cellranger_vdj_index,
+        params.multiqc_config,
+        params.multiqc_logo,
+        params.multiqc_methods_description,
+        params.outdir,
     )
     //
     // SUBWORKFLOW: Run completion tasks

--- a/main.nf
+++ b/main.nf
@@ -11,6 +11,17 @@
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS / WORKFLOWS
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*/
+
+include { SCRNASEQ                } from './workflows/scrnaseq'
+include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+include { getGenomeAttribute      } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     GENOME PARAMETER VALUES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
@@ -31,16 +42,6 @@ params.txp2gene             = getGenomeAttribute('txp2gene')
 params.transcript_fasta     = getGenomeAttribute('transcript_fasta')
 params.motifs               = getGenomeAttribute('motifs')
 params.cellranger_vdj_index = getGenomeAttribute('cellranger_vdj')
-
-/*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    IMPORT FUNCTIONS / MODULES / SUBWORKFLOWS / WORKFLOWS
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*/
-
-include { SCRNASEQ                } from './workflows/scrnaseq'
-include { PIPELINE_INITIALISATION } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
-include { PIPELINE_COMPLETION     } from './subworkflows/local/utils_nfcore_scrnaseq_pipeline'
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -122,21 +123,6 @@ workflow {
         params.monochrome_logs,
         NFCORE_SCRNASEQ.out.multiqc_report
     )
-}
-
-//
-// Get attribute from genome config file e.g. fasta
-//
-def getGenomeAttribute(attribute) {
-    if (params.genomes && params.genome && params.genomes.containsKey(params.genome)) {
-        if (params.genomes[ params.genome ].containsKey(attribute)) {
-            return params.genomes[ params.genome ][ attribute ]
-        } else {
-            return null
-        }
-    } else {
-        return null
-    }
 }
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -17,9 +17,20 @@
 
 // Params cannot be changed if they have been set beforehand
 // Thus, manually provided files are not overwritten by the genome attributes
-params.fasta            = getGenomeAttribute('fasta')
-params.gtf              = getGenomeAttribute('gtf')
-params.star_index       = getGenomeAttribute('star')
+
+// As discussed in #371 it is desirable for users to be able to provide indices via
+// custom igenomes configs in addition to being able to provide them via params directly
+params.fasta                = getGenomeAttribute('fasta')
+params.gtf                  = getGenomeAttribute('gtf')
+params.star_index           = getGenomeAttribute('star')
+params.simpleaf_index       = getGenomeAttribute('simpleaf')
+params.star_index           = getGenomeAttribute('star')
+params.kallisto_index       = getGenomeAttribute('kallisto')
+params.cellranger_index     = getGenomeAttribute('cellranger')
+params.txp2gene             = getGenomeAttribute('txp2gene')
+params.transcript_fasta     = getGenomeAttribute('transcript_fasta')
+params.motifs               = getGenomeAttribute('motifs')
+params.cellranger_vdj_index = getGenomeAttribute('cellranger_vdj')
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -52,6 +63,16 @@ workflow NFCORE_SCRNASEQ {
     //
     SCRNASEQ (
         samplesheet,
+        params.fasta,
+        params.gtf,
+        params.star_index,
+        params.simpleaf_index,
+        params.kallisto_index,
+        params.cellranger_index,
+        params.txp2gene,
+        params.transcript_fasta,
+        params.motifs,
+        params.cellranger_vdj_index,
         params.multiqc_config,
         params.multiqc_logo,
         params.multiqc_methods_description,

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -27,11 +27,21 @@ include { H5AD_CONVERSION                                   } from '../subworkfl
 workflow SCRNASEQ {
 
     take:
-    ch_fastq // channel: [ meta, fastq ] from samplesheet
-    multiqc_config
-    multiqc_logo
-    multiqc_methods_description
-    outdir
+    ch_fastq                    // channel: [ meta, fastq ] from samplesheet
+    fasta                       // val: path-like string (or null)
+    gtf                         // val: path-like string (or null)
+    star_index                  // val: path-like string (or null)
+    simpleaf_index              // val: path-like string (or null)
+    kallisto_index              // val: path-like string (or null)
+    cellranger_index            // val: path-like string (or null)
+    txp2gene                    // val: path-like string (or null)
+    transcript_fasta            // val: path-like string (or null)
+    motifs                      // val: path-like string (or null)
+    cellranger_vdj_index        // val: path-like string (or null)
+    multiqc_config              // val: path-like string (or null)
+    multiqc_logo                // val: path-like string (or null)
+    multiqc_methods_description // val: path-like string (or null)
+    outdir                      // val: string
 
     main:
     ch_multiqc_files = channel.empty()
@@ -48,11 +58,11 @@ workflow SCRNASEQ {
     qcatch_chemistry = qcatch_config.containsKey('protocol') ? qcatch_config['protocol'] : null
 
     // general input and params
-    ch_genome_fasta         = params.fasta                ? file(params.fasta, checkIfExists: true)    : []
-    ch_gtf                  = params.gtf                  ? file(params.gtf, checkIfExists: true)      : []
-    ch_transcript_fasta     = params.transcript_fasta     ? file(params.transcript_fasta)              : []
-    ch_motifs               = params.motifs               ? file(params.motifs)                        : []
-    ch_txp2gene             = params.txp2gene             ? file(params.txp2gene, checkIfExists: true) : []
+    ch_genome_fasta         = fasta            ? file(fasta, checkIfExists: true)            : []
+    ch_gtf                  = gtf              ? file(gtf, checkIfExists: true)              : []
+    ch_transcript_fasta     = transcript_fasta ? file(transcript_fasta, checkIfExists: true) : []
+    ch_motifs               = motifs           ? file(motifs, checkIfExists: true)           : []
+    ch_txp2gene             = txp2gene         ? file(txp2gene, checkIfExists: true)         : []
 
     if (params.barcode_whitelist) {
         ch_barcode_whitelist = file(params.barcode_whitelist, checkIfExists: true)
@@ -67,22 +77,22 @@ workflow SCRNASEQ {
     ch_input = file(params.input)
 
     //kallisto params
-    ch_kallisto_index = params.kallisto_index ? file(params.kallisto_index, checkIfExists: true) : []
-    kb_t1c            = params.kb_t1c         ? file(params.kb_t1c, checkIfExists: true) : []
-    kb_t2c            = params.kb_t2c         ? file(params.kb_t2c, checkIfExists: true) : []
+    ch_kallisto_index = kallisto_index ? file(kallisto_index, checkIfExists: true) : []
+    kb_t1c            = params.kb_t1c  ? file(params.kb_t1c, checkIfExists: true)  : []
+    kb_t2c            = params.kb_t2c  ? file(params.kb_t2c, checkIfExists: true)  : []
 
     //simpleaf params
-    ch_simpleaf_index   = params.simpleaf_index ? file(params.simpleaf_index, checkIfExists: true) : []
+    ch_simpleaf_index   = simpleaf_index ? file(simpleaf_index, checkIfExists: true) : []
 
     //star params
-    star_index        = params.star_index ? file(params.star_index, checkIfExists: true) : null
+    star_index        = star_index ? file(star_index, checkIfExists: true) : null
     ch_star_index     = star_index ? channel.value( [[id: star_index.baseName], star_index] ) : []
 
     //cellranger params
-    ch_cellranger_index = params.cellranger_index ? file(params.cellranger_index, checkIfExists: true) : []
+    ch_cellranger_index = cellranger_index ? file(cellranger_index, checkIfExists: true) : []
 
     //cellrangermulti params
-    cellranger_vdj_index = params.cellranger_vdj_index      ? file(params.cellranger_vdj_index, checkIfExists: true)      : []
+    cellranger_vdj_index = cellranger_vdj_index             ? file(cellranger_vdj_index, checkIfExists: true)             : []
     ch_multi_samplesheet = params.cellranger_multi_barcodes ? file(params.cellranger_multi_barcodes, checkIfExists: true) : []
     empty_file           = file("$projectDir/assets/EMPTY", checkIfExists: true)
 
@@ -98,8 +108,8 @@ workflow SCRNASEQ {
     //
     // Uncompress genome fasta file if required
     //
-    if (params.fasta) {
-        if (params.fasta.endsWith('.gz')) {
+    if (fasta) {
+        if (fasta.endsWith('.gz')) {
             ch_genome_fasta    = GUNZIP_FASTA ( [ [:], ch_genome_fasta ] ).gunzip.map { it[1] }
         } else {
             ch_genome_fasta = channel.value( ch_genome_fasta )
@@ -109,8 +119,8 @@ workflow SCRNASEQ {
     //
     // Uncompress GTF annotation file or create from GFF3 if required
     //
-    if (params.gtf) {
-        if (params.gtf.endsWith('.gz')) {
+    if (gtf) {
+        if (gtf.endsWith('.gz')) {
             ch_gtf      = GUNZIP_GTF ( [ [:], ch_gtf ] ).gunzip.map { it[1] }
         } else {
             ch_gtf = channel.value( ch_gtf )

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -8,7 +8,6 @@ include { paramsSummaryMap                                  } from 'plugin/nf-sc
 include { paramsSummaryMultiqc                              } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML                            } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText                            } from '../subworkflows/local/utils_nfcore_scrnaseq_pipeline'
-include { getGenomeAttribute                                } from '../subworkflows/local/utils_nfcore_scrnaseq_pipeline'
 include { FASTQC_CHECK                                      } from '../subworkflows/local/fastqc'
 include { KALLISTO_BUSTOOLS                                 } from '../subworkflows/local/kallisto_bustools'
 include { SIMPLEAF                                          } from '../subworkflows/local/simpleaf'


### PR DESCRIPTION
This addresses #539 and #393. Also it supersedes #544.

The following changes are included:
1. Added back all index parameters to being theoretically configurable via igenomes, even if no entries exist in the built-in igenomes config
2. Moves some params accessions to the entry workflow as suggested by the [nextflow docs](https://docs.seqera.io/nextflow/strict-syntax#using-params-outside-the-entry-workflow). Later, it should be the goal to move all params accessions here. Not done here to keep the PR focussed