### PR TITLE
Re-route megatests slack notifications to #scrnaseq-dev slack channel

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -41,7 +41,7 @@ jobs:
               enabled = true
               bot {
                 token = '${{ secrets.NFSLACK_BOT_TOKEN }}'
-                channel = 'scrnaseq'
+                channel = 'scrnaseq-dev'
               }
               onStart {
                 enabled = false


### PR DESCRIPTION
This should reduce spam for users of the pipeline in the #scrnaseq channel