### PR TITLE
Create per-subworkflow directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chore
 
+- Migrate local subworkflows to directory-based layout with `main.nf`, matching the new nf-core standard structure for modules and subworkflows ([#553](https://github.com/nf-core/scrnaseq/pull/553))
 - Template update for nf-core/tools v3.5.1 ([#509](https://github.com/nf-core/scrnaseq/pull/509))
 - Template update for nf-core/tools v4.0.2 ([#541](https://github.com/nf-core/scrnaseq/pull/541))
 - Switch `ANNDATAR_CONVERT` to the official Bioconductor **anndataR** package on Bioconda and retire the custom `docker.io/nfcore/anndatar` image. ([#472](https://github.com/nf-core/scrnaseq/pull/472))

--- a/subworkflows/local/align_cellranger/main.nf
+++ b/subworkflows/local/align_cellranger/main.nf
@@ -2,9 +2,9 @@
  * Alignment with Cellranger
  */
 
-include { CELLRANGER_MKGTF } from "../../modules/nf-core/cellranger/mkgtf/main.nf"
-include { CELLRANGER_MKREF } from "../../modules/nf-core/cellranger/mkref/main.nf"
-include { CELLRANGER_COUNT } from "../../modules/nf-core/cellranger/count/main.nf"
+include { CELLRANGER_MKGTF } from "../../../modules/nf-core/cellranger/mkgtf/main.nf"
+include { CELLRANGER_MKREF } from "../../../modules/nf-core/cellranger/mkref/main.nf"
+include { CELLRANGER_COUNT } from "../../../modules/nf-core/cellranger/count/main.nf"
 
 // Define workflow to subset and index a genome region fasta file
 workflow CELLRANGER_ALIGN {

--- a/subworkflows/local/align_cellrangerarc/main.nf
+++ b/subworkflows/local/align_cellrangerarc/main.nf
@@ -2,9 +2,9 @@
  * Alignment with Cellranger Arc
  */
 
-include {CELLRANGERARC_MKGTF} from "../../modules/nf-core/cellrangerarc/mkgtf/main.nf"
-include {CELLRANGERARC_MKREF} from "../../modules/nf-core/cellrangerarc/mkref/main.nf"
-include {CELLRANGERARC_COUNT} from "../../modules/nf-core/cellrangerarc/count/main.nf"
+include {CELLRANGERARC_MKGTF} from "../../../modules/nf-core/cellrangerarc/mkgtf/main.nf"
+include {CELLRANGERARC_MKREF} from "../../../modules/nf-core/cellrangerarc/mkref/main.nf"
+include {CELLRANGERARC_COUNT} from "../../../modules/nf-core/cellrangerarc/count/main.nf"
 
 // Define workflow to subset and index a genome region fasta file
 workflow CELLRANGERARC_ALIGN {

--- a/subworkflows/local/align_cellrangermulti/main.nf
+++ b/subworkflows/local/align_cellrangermulti/main.nf
@@ -1,11 +1,11 @@
 //
 // Include modules
 //
-include { CELLRANGER_MKGTF                  } from "../../modules/nf-core/cellranger/mkgtf/main.nf"
-include { CELLRANGER_MKREF                  } from "../../modules/nf-core/cellranger/mkref/main.nf"
-include { CELLRANGER_MKVDJREF               } from "../../modules/nf-core/cellranger/mkvdjref/main.nf"
-include { CELLRANGER_MULTI                  } from "../../modules/nf-core/cellranger/multi/main.nf"
-include { PARSE_CELLRANGERMULTI_SAMPLESHEET } from "../../modules/local/parse_cellrangermulti_samplesheet"
+include { CELLRANGER_MKGTF                  } from "../../../modules/nf-core/cellranger/mkgtf/main.nf"
+include { CELLRANGER_MKREF                  } from "../../../modules/nf-core/cellranger/mkref/main.nf"
+include { CELLRANGER_MKVDJREF               } from "../../../modules/nf-core/cellranger/mkvdjref/main.nf"
+include { CELLRANGER_MULTI                  } from "../../../modules/nf-core/cellranger/multi/main.nf"
+include { PARSE_CELLRANGERMULTI_SAMPLESHEET } from "../../../modules/local/parse_cellrangermulti_samplesheet"
 
 // Define workflow to subset and index a genome region fasta file
 workflow CELLRANGER_MULTI_ALIGN {

--- a/subworkflows/local/fastqc/main.nf
+++ b/subworkflows/local/fastqc/main.nf
@@ -1,7 +1,7 @@
 //
 // Check input samplesheet and get read channels
 //
-include { FASTQC } from '../../modules/nf-core/fastqc/main'
+include { FASTQC } from '../../../modules/nf-core/fastqc/main'
 
 workflow FASTQC_CHECK {
     take:

--- a/subworkflows/local/h5ad_conversion/main.nf
+++ b/subworkflows/local/h5ad_conversion/main.nf
@@ -1,6 +1,6 @@
 /* --    IMPORT LOCAL MODULES/SUBWORKFLOWS     -- */
-include { CONCAT_H5AD           } from '../../modules/local/concat_h5ad'
-include { ANNDATAR_CONVERT      } from '../../modules/local/anndatar_convert'
+include { CONCAT_H5AD           } from '../../../modules/local/concat_h5ad'
+include { ANNDATAR_CONVERT      } from '../../../modules/local/anndatar_convert'
 
 workflow H5AD_CONVERSION {
 

--- a/subworkflows/local/kallisto_bustools/main.nf
+++ b/subworkflows/local/kallisto_bustools/main.nf
@@ -1,8 +1,8 @@
 /* --    IMPORT LOCAL MODULES/SUBWORKFLOWS     -- */
-include {KALLISTOBUSTOOLS_COUNT }             from '../../modules/nf-core/kallistobustools/count/main'
+include {KALLISTOBUSTOOLS_COUNT }             from '../../../modules/nf-core/kallistobustools/count/main'
 
 /* --    IMPORT NF-CORE MODULES/SUBWORKFLOWS   -- */
-include { KALLISTOBUSTOOLS_REF }        from '../../modules/nf-core/kallistobustools/ref/main'
+include { KALLISTOBUSTOOLS_REF }        from '../../../modules/nf-core/kallistobustools/ref/main'
 
 workflow KALLISTO_BUSTOOLS {
     take:

--- a/subworkflows/local/simpleaf/main.nf
+++ b/subworkflows/local/simpleaf/main.nf
@@ -1,7 +1,7 @@
 /* --    IMPORT LOCAL MODULES/SUBWORKFLOWS     -- */
-include { QCATCH                } from '../../modules/nf-core/qcatch/main'
-include { SIMPLEAF_INDEX        } from '../../modules/nf-core/simpleaf/index'
-include { SIMPLEAF_QUANT        } from '../../modules/nf-core/simpleaf/quant'
+include { QCATCH                } from '../../../modules/nf-core/qcatch/main'
+include { SIMPLEAF_INDEX        } from '../../../modules/nf-core/simpleaf/index'
+include { SIMPLEAF_QUANT        } from '../../../modules/nf-core/simpleaf/quant'
 
 workflow SIMPLEAF {
 

--- a/subworkflows/local/starsolo/main.nf
+++ b/subworkflows/local/starsolo/main.nf
@@ -1,8 +1,8 @@
 /* --    IMPORT LOCAL MODULES/SUBWORKFLOWS     -- */
-include { STAR_ALIGN  } from '../../modules/local/star_align'
+include { STAR_ALIGN  } from '../../../modules/local/star_align'
 
 /* --    IMPORT NF-CORE MODULES/SUBWORKFLOWS   -- */
-include { STAR_GENOMEGENERATE }         from '../../modules/nf-core/star/genomegenerate/main'
+include { STAR_GENOMEGENERATE }         from '../../../modules/nf-core/star/genomegenerate/main'
 
 
 workflow STARSOLO {


### PR DESCRIPTION
This makes our local subworkflows follow the new standard structure of modules and subworkflows

Currently the linting gives a warning when using the old structure