### PR TITLE
Cellranger gtf space incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
+- Add `PREPARE_GENOME` subworkflow to bundle reference FASTA/GTF preparation (gunzip, gene filter, optional GTF source-column fix for Cell Ranger 10)
 - Address [#512](https://github.com/nf-core/scrnaseq/issues/512), adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 - Update `nf-core/cellranger` modules to Cell Ranger `10.0.0`, including output channel handling for multiplexed experiments ([#508](https://github.com/nf-core/scrnaseq/pull/508))
 - Replace **alevinqc** with **qcatch** for simpleaf QC; add `--skip_qcatch` parameter ([#520](https://github.com/nf-core/scrnaseq/pull/520))
@@ -22,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
+- Fix Cell Ranger `mkref` failure with NCBI iGenomes `GRCh38` GTF (`Curated Genomic` in the GTF source column) by replacing spaces in column 2 when using Cell Ranger aligners
 - Fix [#375](https://github.com/nf-core/scrnaseq/issues/375): mismatch between index and probeset when cellranger multi is used without a prebuilt index and an FFPE probeset is passed ([#502](https://github.com/nf-core/scrnaseq/pull/502))
 - Fix [#510](https://github.com/nf-core/scrnaseq/issues/510): Handle files with BOMs. ([#511](https://github.com/nf-core/scrnaseq/pull/511))
 - Fix [#539](https://github.com/nf-core/scrnaseq/issues/539) and [#393](https://github.com/nf-core/scrnaseq/issues/393): genome and aligner index parameter handling by resolving iGenomes attributes in the entry workflow and passing reference paths explicitly into `SCRNASEQ`, restoring configurable pre-built indexes via custom `igenomes` configs (reverts [#483](https://github.com/nf-core/scrnaseq/pull/483) pipeline-wide params approach) ([#545](https://github.com/nf-core/scrnaseq/pull/545))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Add `PREPARE_GENOME` subworkflow to bundle reference FASTA/GTF preparation (gunzip, gene filter, optional GTF source-column fix for Cell Ranger 10)
+- Add `PREPARE_GENOME` subworkflow to bundle reference FASTA/GTF preparation (gunzip, gene filter, optional GTF source-column fix for Cell Ranger 10) ([#554](https://github.com/nf-core/scrnaseq/pull/554))
 - Address [#512](https://github.com/nf-core/scrnaseq/issues/512), adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 - Update `nf-core/cellranger` modules to Cell Ranger `10.0.0`, including output channel handling for multiplexed experiments ([#508](https://github.com/nf-core/scrnaseq/pull/508))
 - Replace **alevinqc** with **qcatch** for simpleaf QC; add `--skip_qcatch` parameter ([#520](https://github.com/nf-core/scrnaseq/pull/520))
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 
-- Fix Cell Ranger `mkref` failure with NCBI iGenomes `GRCh38` GTF (`Curated Genomic` in the GTF source column) by replacing spaces in column 2 when using Cell Ranger aligners
+- Fix Cell Ranger `mkref` failure with NCBI iGenomes `GRCh38` GTF (`Curated Genomic` in the GTF source column) by replacing spaces in column 2 when using Cell Ranger aligners ([#554](https://github.com/nf-core/scrnaseq/pull/554))
 - Fix [#375](https://github.com/nf-core/scrnaseq/issues/375): mismatch between index and probeset when cellranger multi is used without a prebuilt index and an FFPE probeset is passed ([#502](https://github.com/nf-core/scrnaseq/pull/502))
 - Fix [#510](https://github.com/nf-core/scrnaseq/issues/510): Handle files with BOMs. ([#511](https://github.com/nf-core/scrnaseq/pull/511))
 - Fix [#539](https://github.com/nf-core/scrnaseq/issues/539) and [#393](https://github.com/nf-core/scrnaseq/issues/393): genome and aligner index parameter handling by resolving iGenomes attributes in the entry workflow and passing reference paths explicitly into `SCRNASEQ`, restoring configurable pre-built indexes via custom `igenomes` configs (reverts [#483](https://github.com/nf-core/scrnaseq/pull/483) pipeline-wide params approach) ([#545](https://github.com/nf-core/scrnaseq/pull/545))

--- a/conf/igenomes.config
+++ b/conf/igenomes.config
@@ -30,6 +30,7 @@ params {
             bowtie2     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/Bowtie2Index/"
             star        = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/STARIndex/"
             bismark     = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Sequence/BismarkIndex/"
+            gtf_source_has_spaces = true
             gtf         = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.gtf"
             bed12       = "${params.igenomes_base}/Homo_sapiens/NCBI/GRCh38/Annotation/Genes/genes.bed"
             mito_name   = "chrM"

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -70,6 +70,13 @@ process {
         ]
     }
 
+    withName: GTF_SOURCE_FIX {
+        ext.suffix = 'gtf'
+        ext.prefix = { meta.id }
+        ext.args2  = "'BEGIN { FS = OFS = \"\\t\" } /^#/ { print; next } NF >= 2 { gsub(/ /, \"_\", \$2) } { print }'"
+        publishDir = [ enabled: false ]
+    }
+
     withName: CELLRANGER_MKGTF {
         publishDir = [
             path: "${params.outdir}/${params.aligner}/mkgtf",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -384,6 +384,8 @@ The pipeline can resolve reference files from `conf/igenomes.config` when you pr
 
 Some AWS iGenomes STAR indices were generated with older STAR versions and contain legacy metadata. nf-core/scrnaseq includes a compatibility step for these configured iGenomes entries so that legacy STAR indices can run with the STAR version shipped by the pipeline. This support is intended to keep existing iGenomes usage working, not to make legacy indices the preferred reference for new analyses.
 
+Some AWS iGenomes GTF files, such as the NCBI `GRCh38` annotation, contain spaces in the GTF source column (for example `Curated Genomic`). Cell Ranger 10 `mkref` rejects spaces in that field. When using Cell Ranger aligners (`cellranger`, `cellrangerarc`, or `cellrangermulti`) with a configured iGenomes entry flagged for this issue, nf-core/scrnaseq automatically replaces spaces in the source column before reference building. This keeps existing iGenomes usage working with Cell Ranger 10, but is not intended as the preferred reference for new analyses.
+
 > [!WARNING]
 > For production runs, we recommend building fresh indices from current reference files instead of relying on legacy AWS iGenomes indices. The nf-core [reference genome documentation](https://nf-co.re/docs/running/reference-genomes) warns that AWS iGenomes annotations are significantly outdated, for example human annotations from Ensembl release 75, and that GRCh38 iGenomes uses the NCBI assembly rather than the masked Ensembl assembly.
 
@@ -397,6 +399,18 @@ nextflow run nf-core/scrnaseq \
     --fasta reference.fa.gz \
     --gtf annotation.gtf.gz \
     --save_reference \
+    -profile docker
+```
+
+To build a Cell Ranger reference from current annotation files instead of iGenomes, provide FASTA and GTF files directly:
+
+```bash
+nextflow run nf-core/scrnaseq \
+    --input samplesheet.csv \
+    --outdir results \
+    --aligner cellranger \
+    --fasta reference.fa.gz \
+    --gtf annotation.gtf.gz \
     -profile docker
 ```
 

--- a/modules.json
+++ b/modules.json
@@ -60,6 +60,11 @@
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
+                    "gawk": {
+                        "branch": "master",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
+                        "installed_by": ["modules"]
+                    },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "c9ad4d691aa339e478a77847e3ef854ccd21778b",

--- a/modules/nf-core/gawk/environment.yml
+++ b/modules/nf-core/gawk/environment.yml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - conda-forge::gawk=5.3.1

--- a/modules/nf-core/gawk/main.nf
+++ b/modules/nf-core/gawk/main.nf
@@ -1,0 +1,60 @@
+process GAWK {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a1/a125c778baf3865331101a104b60d249ee15fe1dca13bdafd888926cc5490a34/data' :
+        'community.wave.seqera.io/library/gawk:5.3.1--e09efb5dfc4b8156' }"
+
+    input:
+    tuple val(meta), path(input, arity: '0..*')
+    path(program_file)
+    val(disable_redirect_output)
+
+    output:
+    tuple val(meta), path("*.${suffix}"), emit: output
+    tuple val("${task.process}"), val('gawk'), eval("awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//'"), topic: versions, emit: versions_gawk
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args  = task.ext.args  ?: '' // args is used for the main arguments of the tool
+    def args2 = task.ext.args2 ?: '' // args2 is used to specify a program when no program file has been given
+    prefix    = task.ext.prefix ?: "${meta.id}"
+    suffix    = task.ext.suffix ?: "${input.collect{ file -> file.getExtension()}.get(0)}" // use the first extension of the input files
+
+    program    = program_file ? "-f ${program_file}" : "${args2}"
+    lst_gz     = input.findResults{ file -> file.getExtension().endsWith("gz") ? file.toString() : null }
+    unzip      = lst_gz ? "gunzip -q -f ${lst_gz.join(" ")}" : ""
+    input_cmd  = input.collect { file -> file.toString() - ~/\.gz$/ }.join(" ")
+    output_cmd = suffix.endsWith("gz") ? "| gzip > ${prefix}.${suffix}" : "> ${prefix}.${suffix}"
+    output     = disable_redirect_output ? "" : output_cmd
+    cleanup    = lst_gz ? "rm ${lst_gz.collect{ file -> file - ~/\.gz$/ }.join(" ")}" : ""
+
+    input.collect{ file ->
+        assert file.name != "${prefix}.${suffix}" : "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    }
+
+    """
+    ${unzip}
+
+    awk \\
+        ${args} \\
+        ${program} \\
+        ${input_cmd} \\
+        ${output}
+
+    ${cleanup}
+    """
+
+    stub:
+    prefix = task.ext.prefix ?: "${meta.id}"
+    suffix = task.ext.suffix ?: "${input.collect{ file -> file.getExtension()}.get(0)}"
+    def create_cmd = suffix.endsWith("gz") ? "echo '' | gzip >" : "touch"
+
+    """
+    ${create_cmd} ${prefix}.${suffix}
+    """
+}

--- a/modules/nf-core/gawk/meta.yml
+++ b/modules/nf-core/gawk/meta.yml
@@ -1,0 +1,84 @@
+name: "gawk"
+description: |
+  If you are like many computer users, you would frequently like to make changes in various text files
+  wherever certain patterns appear, or extract data from parts of certain lines while discarding the rest.
+  The job is easy with awk, especially the GNU implementation gawk.
+keywords:
+  - gawk
+  - awk
+  - txt
+  - text
+  - file parsing
+tools:
+  - "gawk":
+      description: "GNU awk"
+      homepage: "https://www.gnu.org/software/gawk/"
+      documentation: "https://www.gnu.org/software/gawk/manual/"
+      tool_dev_url: "https://www.gnu.org/prep/ftp.html"
+      licence:
+        - "GPL v3"
+      identifier: ""
+input:
+  - - meta:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - input:
+        type: file
+        description: The input file - Specify the logic that needs to be executed
+          on this file on the `ext.args2` or in the program file. If the files
+          have a `.gz` extension, they will be unzipped using `zcat`.
+        pattern: "*"
+        ontologies: []
+  - program_file:
+      type: file
+      description: Optional file containing logic for awk to execute. If you don't
+        wish to use a file, you can use `ext.args2` to specify the logic.
+      pattern: "*"
+      ontologies: []
+  - disable_redirect_output:
+      type: boolean
+      description: Disable the redirection of awk output to a given file. This is
+        useful if you want to use awk's built-in redirect to write files instead
+        of the shell's redirect.
+output:
+  output:
+    - - meta:
+          type: map
+          description: |
+            Groovy Map containing sample information
+            e.g. [ id:'test', single_end:false ]
+      - "*.${suffix}":
+          type: file
+          description: The output file - if using shell redirection, specify the
+            name of this file using `ext.prefix` and the extension using
+            `ext.suffix`. Otherwise, ensure the awk program produces files with
+            the extension in `ext.suffix`.
+          pattern: "*"
+          ontologies: []
+  versions_gawk:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - gawk:
+          type: string
+          description: The name of the tool
+      - awk -Wversion | sed '1!d; s/.*Awk //; s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+authors:
+  - "@nvnieuwk"
+maintainers:
+  - "@nvnieuwk"

--- a/modules/nf-core/gawk/tests/main.nf.test
+++ b/modules/nf-core/gawk/tests/main.nf.test
@@ -1,0 +1,211 @@
+nextflow_process {
+
+    name "Test Process GAWK"
+    script "../main.nf"
+    process "GAWK"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "gawk"
+
+    config "./nextflow.config"
+
+    test("Convert fasta to bed") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Convert fasta to bed - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+        }
+    }
+
+    test("Convert fasta to bed with program file") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = Channel.of('BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Convert fasta to bed using awk redirect instead of shell redirect") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 > "test.bed" }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = true
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Extract first column from multiple files") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Unzip files before processing") {
+        when {
+            params {
+                gawk_suffix = "bed"
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    [file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA12878_chrM.vcf.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/illumina/vcf/NA24385_sv.vcf.gz', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('/^#CHROM/ { print \$1, \$10 }').collectFile(name:"column_header.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Compress after processing") {
+        when {
+            params {
+                gawk_suffix = "txt.gz"
+                gawk_args2  = '\'BEGIN { FS = OFS = "\t"}; { print \$1, "0", \$2 }\''
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ],
+                    file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta.fai', checkIfExists: true)
+                ]
+                input[1] = []
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(sanitizeOutput(process.out)).match()
+        }
+    }
+
+    test("Input and output files are similar") {
+        when {
+            params {
+                gawk_suffix = "txt"
+                gawk_args   = ""
+                gawk_args2  = ""
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'hello' ],
+                    [file(params.modules_testdata_base_path + 'generic/txt/hello.txt', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'generic/txt/species_names.txt', checkIfExists: true)]
+                ]
+                input[1] = Channel.of('BEGIN {FS=" "}; {print \$1}').collectFile(name:"program.awk")
+                input[2] = false
+                """
+            }
+        }
+
+        then {
+            assert process.failed
+            assert process.errorReport.contains("Input and output names are the same, set prefix in module configuration to disambiguate!")
+        }
+    }
+}

--- a/modules/nf-core/gawk/tests/main.nf.test.snap
+++ b/modules/nf-core/gawk/tests/main.nf.test.snap
@@ -1,0 +1,199 @@
+{
+    "Compress after processing": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt.gz:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:50.761549948",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Convert fasta to bed": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:30:50.804933797",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Convert fasta to bed with program file": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:10.838989113",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Convert fasta to bed - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ],
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:00.182649403",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Extract first column from multiple files": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,566c51674bd643227bb2d83e0963376d"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:30.796772884",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Unzip files before processing": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,1e31ebd4a060aab5433bbbd9ab24e403"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:40.72259289",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    },
+    "Convert fasta to bed using awk redirect instead of shell redirect": {
+        "content": [
+            {
+                "output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.bed:md5,87a15eb9c2ff20ccd5cd8735a28708f7"
+                    ]
+                ],
+                "versions_gawk": [
+                    [
+                        "GAWK",
+                        "gawk",
+                        "5.3.1"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-03-04T11:31:20.33222004",
+        "meta": {
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
+    }
+}

--- a/modules/nf-core/gawk/tests/nextflow.config
+++ b/modules/nf-core/gawk/tests/nextflow.config
@@ -1,0 +1,6 @@
+process {
+    withName: GAWK {
+        ext.suffix = params.gawk_suffix
+        ext.args2  = params.gawk_args2
+    }
+}

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -46,6 +46,14 @@ workflow PREPARE_GENOME {
     ch_versions = ch_versions.mix(GTF_GENE_FILTER.out.versions)
 
     if (gtf_source_fix) {
+        // iGenomes GTF annotations with spaces in the source column (e.g. NCBI GRCh38
+        // "Curated Genomic") fail Cell Ranger 10 mkref. Opt-in per genome via
+        // gtf_source_has_spaces in the genomes map; see usage docs.
+        log.warn(
+            "Using an iGenomes GTF with spaces in the source column. nf-core/scrnaseq will rewrite the GTF source field for " +
+            "Cell Ranger compatibility, but we recommend current reference annotations for production runs. See " +
+            "https://nf-co.re/scrnaseq/dev/docs/usage#reference-genome-options"
+        )
         ch_gtf_meta = ch_gtf.map { reference_gtf ->
             [[id: "${reference_gtf.baseName}.source_fixed"], reference_gtf]
         }

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -1,0 +1,61 @@
+/*
+ * Prepare reference FASTA and GTF for alignment (gunzip, filter to genome sequences, optional GTF source fix)
+ */
+
+include { GUNZIP as GUNZIP_FASTA } from '../../../modules/nf-core/gunzip/main'
+include { GUNZIP as GUNZIP_GTF   } from '../../../modules/nf-core/gunzip/main'
+include { GTF_GENE_FILTER          } from '../../../modules/local/gtf_gene_filter/main'
+include { GAWK as GTF_SOURCE_FIX   } from '../../../modules/nf-core/gawk/main'
+
+workflow PREPARE_GENOME {
+    take:
+    fasta
+    gtf
+    gtf_source_fix
+
+    main:
+    ch_versions     = channel.empty()
+
+    if (fasta) {
+        ch_fasta = file(fasta, checkIfExists: true)
+        if (fasta.endsWith('.gz')) {
+            ch_fasta = GUNZIP_FASTA([[:], ch_fasta]).gunzip
+                .map { _meta, fasta_file -> fasta_file }.collect()
+        }
+        else {
+            ch_fasta = channel.value(ch_fasta)
+        }
+    }
+
+    if (gtf) {
+        ch_gtf = file(gtf, checkIfExists: true)
+        if (gtf.endsWith('.gz')) {
+            ch_gtf = GUNZIP_GTF([[:], ch_gtf]).gunzip
+                .map { _meta, gtf_file -> gtf_file }.collect()
+        }
+        else {
+            ch_gtf = channel.value(ch_gtf)
+        }
+    }
+
+    GTF_GENE_FILTER(
+        ch_fasta,
+        ch_gtf
+    )
+    ch_gtf = GTF_GENE_FILTER.out.gtf
+    ch_versions = ch_versions.mix(GTF_GENE_FILTER.out.versions)
+
+    if (gtf_source_fix) {
+        ch_gtf_meta = ch_gtf.map { reference_gtf ->
+            [[id: "${reference_gtf.baseName}.source_fixed"], reference_gtf]
+        }
+        GTF_SOURCE_FIX(ch_gtf_meta, [], false)
+        ch_gtf = GTF_SOURCE_FIX.out.output.map { _meta, reference_gtf -> reference_gtf }
+        ch_versions = ch_versions.mix(GTF_SOURCE_FIX.out.versions_gawk)
+    }
+
+    emit:
+    fasta      = ch_fasta
+    gtf        = ch_gtf
+    versions   = ch_versions
+}

--- a/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_scrnaseq_pipeline/main.nf
@@ -361,6 +361,17 @@ def getGenomeAttribute(attribute) {
 }
 
 //
+// iGenomes GTF annotations with spaces in the GTF source column (e.g. NCBI RefSeq "Curated Genomic")
+// are incompatible with Cell Ranger 10 mkref; opt-in per genome via gtf_source_has_spaces.
+//
+def gtfSourceFixNeeded() {
+    def genome_entry = params.genomes && params.genome ? params.genomes[params.genome] : null
+    return params.aligner in ['cellranger', 'cellrangerarc', 'cellrangermulti'] &&
+        genome_entry?.gtf_source_has_spaces &&
+        params.gtf == genome_entry.gtf
+}
+
+//
 // Exit pipeline if incorrect --genome key provided
 //
 def genomeExistsError() {

--- a/tests/main_pipeline_cellranger.nf.test.snap
+++ b/tests/main_pipeline_cellranger.nf.test.snap
@@ -15,6 +15,9 @@
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
+                "GTF_GENE_FILTER": {
+                    "python": "3.9.5"
+                },
                 "MTX_TO_H5AD": {
                     "anndata": "0.10.8",
                     "pandas": "2.2.2",
@@ -379,7 +382,7 @@
                 "multiqc_general_stats.txt:md5,92a7a66e313e6ce2d13da53b501b5c0c"
             ]
         ],
-        "timestamp": "2026-05-12T17:24:09.68258612",
+        "timestamp": "2026-05-29T08:58:41.232483981",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"

--- a/tests/main_pipeline_cellrangerarc.nf.test.snap
+++ b/tests/main_pipeline_cellrangerarc.nf.test.snap
@@ -15,6 +15,9 @@
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
+                "GTF_GENE_FILTER": {
+                    "python": "3.9.5"
+                },
                 "MTX_TO_H5AD": {
                     "anndata": "0.10.8",
                     "pandas": "2.2.2",
@@ -278,7 +281,7 @@
                 "multiqc_general_stats.txt:md5,fd84f94100989affc666904a2f34c40c"
             ]
         ],
-        "timestamp": "2026-05-12T17:22:39.296468162",
+        "timestamp": "2026-05-29T08:55:55.275563341",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"

--- a/tests/main_pipeline_kallisto.nf.test.snap
+++ b/tests/main_pipeline_kallisto.nf.test.snap
@@ -6,6 +6,9 @@
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
+                "GTF_GENE_FILTER": {
+                    "python": "3.9.5"
+                },
                 "KALLISTOBUSTOOLS_COUNT": {
                     "kallistobustools": "0.28.2"
                 },
@@ -208,7 +211,7 @@
                 "multiqc_general_stats.txt:md5,dac8af62b04fd0880801f5d5c503c472"
             ]
         ],
-        "timestamp": "2026-05-12T17:14:06.244757369",
+        "timestamp": "2026-05-29T08:47:13.634285305",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"

--- a/tests/main_pipeline_simpleaf.nf.test.snap
+++ b/tests/main_pipeline_simpleaf.nf.test.snap
@@ -6,6 +6,9 @@
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
+                "GTF_GENE_FILTER": {
+                    "python": "3.9.5"
+                },
                 "MTX_TO_H5AD": {
                     "anndata": "0.10.8",
                     "pandas": "2.2.2",
@@ -179,7 +182,7 @@
                 "Sample_Y_raw_matrix.seurat.rds:md5,67ce29c647359ca4de0d99e618908196"
             ]
         ],
-        "timestamp": "2026-05-12T17:14:40.055073206",
+        "timestamp": "2026-05-29T10:25:49.319072824",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"

--- a/tests/main_pipeline_star.nf.test.snap
+++ b/tests/main_pipeline_star.nf.test.snap
@@ -5,6 +5,9 @@
                 "FASTQC": {
                     "fastqc": "0.12.1"
                 },
+                "GTF_GENE_FILTER": {
+                    "python": "3.9.5"
+                },
                 "MTX_TO_H5AD": {
                     "anndata": "0.10.8",
                     "pandas": "2.2.2",
@@ -228,7 +231,7 @@
                 "Sample_Y_raw_matrix.seurat.rds:md5,1e366fa8c2ae00e91dc5b1f5101414ce"
             ]
         ],
-        "timestamp": "2026-05-12T17:20:00.200180498",
+        "timestamp": "2026-05-29T08:11:18.253843062",
         "meta": {
             "nf-test": "0.9.4",
             "nextflow": "26.04.0"

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -8,6 +8,8 @@ include { paramsSummaryMap                                  } from 'plugin/nf-sc
 include { paramsSummaryMultiqc                              } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML                            } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText                            } from '../subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+include { gtfSourceFixNeeded                                  } from '../subworkflows/local/utils_nfcore_scrnaseq_pipeline'
+include { PREPARE_GENOME                                      } from '../subworkflows/local/prepare_genome/main'
 include { FASTQC_CHECK                                      } from '../subworkflows/local/fastqc'
 include { KALLISTO_BUSTOOLS                                 } from '../subworkflows/local/kallisto_bustools'
 include { SIMPLEAF                                          } from '../subworkflows/local/simpleaf'
@@ -17,9 +19,6 @@ include { CELLRANGER_MULTI_ALIGN                            } from "../subworkfl
 include { CELLRANGERARC_ALIGN                               } from "../subworkflows/local/align_cellrangerarc"
 include { MTX_TO_H5AD                                       } from '../modules/local/mtx_to_h5ad'
 include { H5AD_REMOVEBACKGROUND_BARCODES_CELLBENDER_ANNDATA } from '../subworkflows/nf-core/h5ad_removebackground_barcodes_cellbender_anndata'
-include { GTF_GENE_FILTER                                   } from '../modules/local/gtf_gene_filter'
-include { GUNZIP as GUNZIP_FASTA                            } from '../modules/nf-core/gunzip/main'
-include { GUNZIP as GUNZIP_GTF                              } from '../modules/nf-core/gunzip/main'
 include { H5AD_CONVERSION                                   } from '../subworkflows/local/h5ad_conversion'
 
 
@@ -57,8 +56,6 @@ workflow SCRNASEQ {
     qcatch_chemistry = qcatch_config.containsKey('protocol') ? qcatch_config['protocol'] : null
 
     // general input and params
-    ch_genome_fasta         = fasta            ? file(fasta, checkIfExists: true)            : []
-    ch_gtf                  = gtf              ? file(gtf, checkIfExists: true)              : []
     ch_transcript_fasta     = transcript_fasta ? file(transcript_fasta, checkIfExists: true) : []
     ch_motifs               = motifs           ? file(motifs, checkIfExists: true)           : []
     ch_txp2gene             = txp2gene         ? file(txp2gene, checkIfExists: true)         : []
@@ -105,29 +102,16 @@ workflow SCRNASEQ {
     }
 
     //
-    // Uncompress genome fasta file if required
+    // Prepare reference FASTA and GTF (gunzip, filter, optional Cell Ranger GTF source fix)
     //
-    if (fasta) {
-        if (fasta.endsWith('.gz')) {
-            ch_genome_fasta    = GUNZIP_FASTA ( [ [:], ch_genome_fasta ] ).gunzip.map { it[1] }
-        } else {
-            ch_genome_fasta = channel.value( ch_genome_fasta )
-        }
-    }
-
-    //
-    // Uncompress GTF annotation file or create from GFF3 if required
-    //
-    if (gtf) {
-        if (gtf.endsWith('.gz')) {
-            ch_gtf      = GUNZIP_GTF ( [ [:], ch_gtf ] ).gunzip.map { it[1] }
-        } else {
-            ch_gtf = channel.value( ch_gtf )
-        }
-    }
-
-    // filter gtf
-    ch_filter_gtf = ch_gtf ? GTF_GENE_FILTER ( ch_genome_fasta, ch_gtf ).gtf : []
+    PREPARE_GENOME(
+        fasta,
+        gtf,
+        gtfSourceFixNeeded()
+    )
+    ch_genome_fasta = PREPARE_GENOME.out.fasta
+    ch_filter_gtf   = PREPARE_GENOME.out.gtf
+    ch_versions     = ch_versions.mix(PREPARE_GENOME.out.versions)
 
     // Run kallisto bustools pipeline
     if (params.aligner == "kallisto") {


### PR DESCRIPTION
This causes failure in the megatests, and generally it is not optimal if the genomes we provide are not fully compatible with the pipeline. This issue occurs only with the `GRCh38` genome, which is probably the one used most often. While I was at it, I also created a dedicated subworkflow for genome preparation, to reduce the complexity of the main workflow.