### PR TITLE
feat(qcatch): nest qcatch_protocol, expose n_partitions, run QCatch for all simpleaf protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Address [#512](https://github.com/nf-core/scrnaseq/issues/512), adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 - Update `nf-core/cellranger` modules to Cell Ranger `10.0.0`, including output channel handling for multiplexed experiments ([#508](https://github.com/nf-core/scrnaseq/pull/508))
 - Replace **alevinqc** with **qcatch** for simpleaf QC; add `--skip_qcatch` parameter ([#520](https://github.com/nf-core/scrnaseq/pull/520))
-- Expose `--qcatch_n_partitions` for QCatch's empty-drops partition count, and run QCatch QC for all simpleaf protocols (chemistry omitted/inferred when a protocol has no QCatch mapping) ([#558](https://github.com/nf-core/scrnaseq/pull/558))
+- Expose `--qcatch_n_partitions` for QCatch's empty-drops partition count, and run QCatch QC for all simpleaf protocols (chemistry omitted/inferred when a protocol has no QCatch mapping) ([#560](https://github.com/nf-core/scrnaseq/pull/560))
 - Add legacy STAR iGenomes index compatibility (rnaseq-style `star_legacy` handling and `STAR_GENOMEPARAMS_UPGRADE` to rewrite STAR 2.6.x `genomeParameters.txt` metadata for modern STAR) ([#552](https://github.com/nf-core/scrnaseq/pull/552))
 
 ### Chore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Address [#512](https://github.com/nf-core/scrnaseq/issues/512), adding early validation of the cellranger multi barcode sheet ([#513](https://github.com/nf-core/scrnaseq/pull/513))
 - Update `nf-core/cellranger` modules to Cell Ranger `10.0.0`, including output channel handling for multiplexed experiments ([#508](https://github.com/nf-core/scrnaseq/pull/508))
 - Replace **alevinqc** with **qcatch** for simpleaf QC; add `--skip_qcatch` parameter ([#520](https://github.com/nf-core/scrnaseq/pull/520))
+- Expose `--qcatch_n_partitions` for QCatch's empty-drops partition count, and run QCatch QC for all simpleaf protocols (chemistry omitted/inferred when a protocol has no QCatch mapping) ([#558](https://github.com/nf-core/scrnaseq/pull/558))
 - Add legacy STAR iGenomes index compatibility (rnaseq-style `star_legacy` handling and `STAR_GENOMEPARAMS_UPGRADE` to rewrite STAR 2.6.x `genomeParameters.txt` metadata for modern STAR) ([#552](https://github.com/nf-core/scrnaseq/pull/552))
 
 ### Chore

--- a/assets/protocols.json
+++ b/assets/protocols.json
@@ -6,35 +6,21 @@
         },
         "10XV2": {
             "protocol": "10xv2",
-            "whitelist": "assets/whitelist/10x_V2_barcode_whitelist.txt.gz"
+            "whitelist": "assets/whitelist/10x_V2_barcode_whitelist.txt.gz",
+            "qcatch_protocol": "10X_3p_v2"
         },
         "10XV3": {
             "protocol": "10xv3",
-            "whitelist": "assets/whitelist/10x_V3_barcode_whitelist.txt.gz"
+            "whitelist": "assets/whitelist/10x_V3_barcode_whitelist.txt.gz",
+            "qcatch_protocol": "10X_3p_v3"
         },
         "10XV4": {
             "protocol": "10xv4-3p",
-            "whitelist": "assets/whitelist/10x_V4_barcode_whitelist.txt.gz"
+            "whitelist": "assets/whitelist/10x_V4_barcode_whitelist.txt.gz",
+            "qcatch_protocol": "10X_3p_v4"
         },
         "dropseq": {
             "protocol": "dropseq"
-        }
-    },
-    "qcatch": {
-        "10XV1": {
-            "protocol": null
-        },
-        "10XV2": {
-            "protocol": "10X_3p_v2"
-        },
-        "10XV3": {
-            "protocol": "10X_3p_v3"
-        },
-        "10XV4": {
-            "protocol": "10X_3p_v4"
-        },
-        "dropseq": {
-            "protocol": null
         }
     },
     "cellranger": {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -152,6 +152,7 @@ process {
         ext.args = {
             [
                 params.remove_doublets ? '--remove_doublets --visualize_doublets' : '',
+                params.qcatch_n_partitions ? "--n_partitions ${params.qcatch_n_partitions}" : '',
             ].join(' ').trim()
         }
         publishDir = [

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,6 +120,8 @@ Simpleaf has the ability to pass custom chemistries to Alevin-fry, in a slightly
 
 When using simpleaf, the same `--protocol` value is also used to select the qcatch chemistry for QC. Set `--skip_qcatch` to skip qcatch report generation.
 
+For protocols without a QCatch chemistry mapping (e.g. `10XV1`, `dropseq`), QCatch omits `--chemistry` and instead infers the chemistry from the quantification metadata. For non-10X / custom assays where inference is not possible, set `--qcatch_n_partitions <int>` to provide the partition count (max number of barcodes) for QCatch's empty-drops step.
+
 For more details, see Simpleaf's paper, [He _et al._ 2023](https://doi.org/10.1093/bioinformatics/btad614) and the [detailed description](https://hackmd.io/@PI7Og0l1ReeBZu_pjQGUQQ/rJMgmvr13).
 
 #### Cell Ranger ARC

--- a/modules.json
+++ b/modules.json
@@ -8,157 +8,112 @@
                     "anndata/barcodes": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "h5ad_removebackground_barcodes_cellbender_anndata"
-                        ]
+                        "installed_by": ["h5ad_removebackground_barcodes_cellbender_anndata"]
                     },
                     "cellbender/removebackground": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "h5ad_removebackground_barcodes_cellbender_anndata",
-                            "modules"
-                        ]
+                        "installed_by": ["h5ad_removebackground_barcodes_cellbender_anndata", "modules"]
                     },
                     "cellranger/count": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellranger/mkgtf": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellranger/mkref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellranger/mkvdjref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellranger/multi": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellrangerarc/count": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellrangerarc/mkgtf": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cellrangerarc/mkref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gawk": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "c9ad4d691aa339e478a77847e3ef854ccd21778b",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0902eac3012baaf4f9ab6513c8c55acc9353c96c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kallistobustools/count": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kallistobustools/ref": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "008f9d3e61209bf995edac3ba531f54e269e1215",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "qcatch": {
                         "branch": "master",
                         "git_sha": "4c594931203e827ba22f06bca97b3f9d633f89db",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "simpleaf/index": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "simpleaf/quant": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "star/genomegenerate": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "unzip": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             },
@@ -167,30 +122,22 @@
                     "h5ad_removebackground_barcodes_cellbender_anndata": {
                         "branch": "master",
                         "git_sha": "b7d92b962382d64514f6c5ec6901078d90cc5a44",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "a3fb7351b1fdb2b1de282b765816bbea190e86a8",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
-                        "installed_by": [
-                            "subworkflows"
-                        ]
+                        "installed_by": ["subworkflows"]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,112 +8,157 @@
                     "anndata/barcodes": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["h5ad_removebackground_barcodes_cellbender_anndata"]
+                        "installed_by": [
+                            "h5ad_removebackground_barcodes_cellbender_anndata"
+                        ]
                     },
                     "cellbender/removebackground": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["h5ad_removebackground_barcodes_cellbender_anndata", "modules"]
+                        "installed_by": [
+                            "h5ad_removebackground_barcodes_cellbender_anndata",
+                            "modules"
+                        ]
                     },
                     "cellranger/count": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellranger/mkgtf": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellranger/mkref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellranger/mkvdjref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellranger/multi": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellrangerarc/count": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellrangerarc/mkgtf": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cellrangerarc/mkref": {
                         "branch": "master",
                         "git_sha": "21e4662ae927fdbc5fc04eec9bde38b0689d4954",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gawk": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gffread": {
                         "branch": "master",
                         "git_sha": "c9ad4d691aa339e478a77847e3ef854ccd21778b",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "0902eac3012baaf4f9ab6513c8c55acc9353c96c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallistobustools/count": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kallistobustools/ref": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "008f9d3e61209bf995edac3ba531f54e269e1215",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "qcatch": {
                         "branch": "master",
-                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "git_sha": "4c594931203e827ba22f06bca97b3f9d633f89db",
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "simpleaf/index": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "simpleaf/quant": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "star/genomegenerate": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "unzip": {
                         "branch": "master",
                         "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             },
@@ -122,22 +167,30 @@
                     "h5ad_removebackground_barcodes_cellbender_anndata": {
                         "branch": "master",
                         "git_sha": "b7d92b962382d64514f6c5ec6901078d90cc5a44",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nextflow_pipeline": {
                         "branch": "master",
                         "git_sha": "05954dab2ff481bcb999f24455da29a5828af08d",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfcore_pipeline": {
                         "branch": "master",
                         "git_sha": "a3fb7351b1fdb2b1de282b765816bbea190e86a8",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     },
                     "utils_nfschema_plugin": {
                         "branch": "master",
                         "git_sha": "fdc08b8b1ae74f56686ce21f7ea11ad11990ce57",
-                        "installed_by": ["subworkflows"]
+                        "installed_by": [
+                            "subworkflows"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/qcatch/environment.yml
+++ b/modules/nf-core/qcatch/environment.yml
@@ -6,6 +6,6 @@ channels:
 
 dependencies:
   - conda-forge::pip=25.3
-  - conda-forge::python=3.14.3
+  - conda-forge::python=3.14.6
   - pip:
-      - qcatch==0.2.11
+      - qcatch==0.2.12

--- a/modules/nf-core/qcatch/main.nf
+++ b/modules/nf-core/qcatch/main.nf
@@ -4,8 +4,8 @@ process QCATCH {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/62/6233ebf32d1ce85d41398121c4b8c1449779fa13b1529e702e067bfca6f835b7/data':
-        'community.wave.seqera.io/library/pip_qcatch:05d150ed59c3ae84' }"
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/a7/a7d0112866550e3bcf97c40104596a3ca2ecbc26c13cf919fe76587554528281/data':
+        'community.wave.seqera.io/library/pip_qcatch:03b88593a5cca75b' }"
     input:
     tuple val(meta), val(chemistry), path(quant_dir)
 
@@ -13,7 +13,7 @@ process QCATCH {
     tuple val(meta), path("*.html")                , emit: report
     tuple val(meta), path("*_filtered_quants.h5ad") , emit: filtered_h5ad
     tuple val(meta), path("*_metrics_summary.csv")  , emit: metrics_summary
-    path  "versions.yml"                                    , emit: versions
+    tuple val("${task.process}"), val('qcatch'), eval("qcatch --version | sed -e 's/qcatch //g'"), emit: versions_qcatch, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,12 +21,13 @@ process QCATCH {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def chemistry_arg = chemistry ? "--chemistry ${chemistry}" : ''
 
     """
     qcatch \\
         --input ${quant_dir} \\
         --output ${prefix} \\
-        --chemistry ${chemistry} \\
+        ${chemistry_arg} \\
         --save_filtered_h5ad \\
         --export_summary_table \\
         ${args}
@@ -34,11 +35,6 @@ process QCATCH {
     mv ${prefix}/QCatch_report.html ${prefix}_qcatch_report.html
     mv ${prefix}/filtered_quants.h5ad ${prefix}_filtered_quants.h5ad
     mv ${prefix}/summary_table.csv ${prefix}_metrics_summary.csv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        qcatch: \$(qcatch --version | sed -e "s/qcatch //g")
-    END_VERSIONS
     """
 
     stub:
@@ -48,10 +44,5 @@ process QCATCH {
     touch ${prefix}_qcatch_report.html
     touch ${prefix}_filtered_quants.h5ad
     touch ${prefix}_metrics_summary.csv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        qcatch: \$(qcatch --version | sed -e "s/qcatch //g")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/qcatch/meta.yml
+++ b/modules/nf-core/qcatch/meta.yml
@@ -70,14 +70,27 @@ output:
             CSV file containing summary metrics from QC analysis
           pattern: "*_metrics_summary.csv"
           ontologies: []
+  versions_qcatch:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - qcatch:
+          type: string
+          description: The name of the tool
+      - qcatch --version | sed -e 's/qcatch //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: |
-          File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - qcatch:
+          type: string
+          description: The name of the tool
+      - qcatch --version | sed -e 's/qcatch //g':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@wzheng0520"
   - "@dongzehe"

--- a/modules/nf-core/qcatch/tests/main.nf.test
+++ b/modules/nf-core/qcatch/tests/main.nf.test
@@ -44,8 +44,7 @@ nextflow_process {
                     path(process.out.report[0][1]).size(),
                     process.out.filtered_h5ad,
                     process.out.metrics_summary,
-                    process.out.versions,
-                    path(process.out.versions[0]).yaml
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match() }
             )
         }
@@ -84,7 +83,7 @@ nextflow_process {
                 { assert path(process.out.report.get(0).get(1)).size() > 0 },
                 { assert path(process.out.filtered_h5ad.get(0).get(1)).size() > 0 },
                 { assert path(process.out.metrics_summary.get(0).get(1)).size() > 0 },
-                { assert snapshot(process.out.versions).match("remove_doublets_versions") }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match("remove_doublets_versions") }
             )
         }
     }

--- a/modules/nf-core/qcatch/tests/main.nf.test.snap
+++ b/modules/nf-core/qcatch/tests/main.nf.test.snap
@@ -1,13 +1,13 @@
 {
     "test_qcatch - 1k_pbmc_v3": {
         "content": [
-            4049155,
+            4050683,
             [
                 [
                     {
                         "id": "1k_pbmc_v3"
                     },
-                    "1k_pbmc_v3_filtered_quants.h5ad:md5,52f8feab612b585032d52ea8817caf99"
+                    "1k_pbmc_v3_filtered_quants.h5ad:md5,7e27940bb5286e04addc1c85b20a6986"
                 ]
             ],
             [
@@ -18,20 +18,21 @@
                     "1k_pbmc_v3_metrics_summary.csv:md5,22deb2f3aea4e4abf476970576362428"
                 ]
             ],
-            [
-                "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
-            ],
             {
-                "QCATCH": {
-                    "qcatch": "version 0.2.11"
-                }
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
+                ]
             }
         ],
+        "timestamp": "2026-06-16T20:39:20.393084026",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:31:02.954262822"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "test_qcatch - stub": {
         "content": [
@@ -61,7 +62,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
                 ],
                 "filtered_h5ad": [
                     [
@@ -87,27 +92,37 @@
                         "test_stub_qcatch_report.html:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-16T20:32:42.256409881",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:34:17.397780003"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     },
     "remove_doublets_versions": {
         "content": [
-            [
-                "versions.yml:md5,bd75bc6d669b1ce72b4094e55d93d045"
-            ]
+            {
+                "versions_qcatch": [
+                    [
+                        "QCATCH",
+                        "qcatch",
+                        "version 0.2.12"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-16T20:42:17.676057899",
         "meta": {
-            "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
-        },
-        "timestamp": "2026-02-25T16:34:00.029602757"
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,7 @@ params {
     simpleaf_umi_resolution = "cr-like"
     skip_qcatch         = false
     remove_doublets     = false
+    qcatch_n_partitions = null
 
     // kallisto bustools parameters
     kb_workflow       = "standard"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -207,6 +207,11 @@
                     "type": "boolean",
                     "description": "Enable doublet detection and removal using Scrublet via QCatch.",
                     "help_text": "When enabled, QCatch will run Scrublet-based doublet detection and removal on the filtered count matrix, and include doublet visualizations in the QC report. Only applies when using the simpleaf aligner with QCatch enabled."
+                },
+                "qcatch_n_partitions": {
+                    "type": "integer",
+                    "description": "Number of partitions (max barcodes) for QCatch's empty_drops step.",
+                    "help_text": "Passed to QCatch as `--n_partitions`. Use for non-10X / custom assays (e.g. drop-seq) where QCatch has no chemistry mapping and cannot reliably auto-infer the partition range. Only applies when using the simpleaf aligner with QCatch enabled."
                 }
             }
         },

--- a/subworkflows/local/simpleaf/main.nf
+++ b/subworkflows/local/simpleaf/main.nf
@@ -118,13 +118,16 @@ workflow SIMPLEAF {
 
     /*
     * Run qcatch QC (optional)
+    * qcatch_chemistry may be null for protocols without a QCatch chemistry mapping
+    * (e.g. 10XV1 and dropseq); the module then omits --chemistry and QCatch infers
+    * it from metadata or uses --n_partitions (set via --qcatch_n_partitions).
     */
     ch_qcatch_report = channel.empty()
     if ( !skip_qcatch ) {
         // Map quant channel to include chemistry for qcatch: tuple(meta, chemistry, quant_dir)
         ch_qcatch_input = ch_af_quant.map { meta, quant_dir -> [meta, qcatch_chemistry, quant_dir] }
         QCATCH( ch_qcatch_input )
-        ch_versions = ch_versions.mix(QCATCH.out.versions)
+        // QCATCH emits versions via the `versions` topic (collected in the main workflow)
         ch_qcatch_report = QCATCH.out.report
     }
 

--- a/workflows/scrnaseq.nf
+++ b/workflows/scrnaseq.nf
@@ -52,9 +52,8 @@ workflow SCRNASEQ {
         error "Only cellranger supports `protocol = 'auto'`. Please specify the protocol manually!"
     }
 
-    // Get qcatch chemistry for simpleaf QC (if using simpleaf aligner)
-    qcatch_config = params.aligner == "simpleaf" ? Utils.getProtocol(workflow, log, "qcatch", params.protocol) : [:]
-    qcatch_chemistry = qcatch_config.containsKey('protocol') ? qcatch_config['protocol'] : null
+    // Get qcatch chemistry for simpleaf QC (derived from the simpleaf protocol; null if unmapped)
+    qcatch_chemistry = params.aligner == "simpleaf" ? protocol_config['qcatch_protocol'] : null
 
     // general input and params
     ch_transcript_fasta     = transcript_fasta ? file(transcript_fasta, checkIfExists: true) : []


### PR DESCRIPTION
## Summary

Refines the simpleaf→QCatch QC integration, following up on review feedback in #558.

### Changes

**1. `protocols.json`: nest QCatch chemistry under `simpleaf`**
QCatch uses different chemistry strings than simpleaf (e.g. `10X_3p_v3` vs `10xv3`), so a mapping is needed. Previously this lived in a top-level `qcatch` key, which read like a separate aligner. It now lives as a `qcatch_protocol` field inside each `simpleaf` protocol entry, alongside `protocol` and `whitelist`:

```json
"10XV3": { "protocol": "10xv3", "whitelist": "...", "qcatch_protocol": "10X_3p_v3" }
```

`workflows/scrnaseq.nf` derives `qcatch_chemistry` from `protocol_config['qcatch_protocol']` (simpleaf-only; `null` otherwise).

**2. Expose `--qcatch_n_partitions`**
New optional param wired into the `QCATCH` `ext.args`, for non-10X / custom assays where QCatch has no chemistry mapping and can't auto-infer the partition range.

**3. Run QCatch for all simpleaf protocols**
Dropped the previous "skip when chemistry is null" guard. The updated module omits `--chemistry` when unmapped (`10XV1`, `dropseq`) and QCatch infers from metadata or uses `--n_partitions`.

**4. Sync `nf-core/qcatch` module → 0.2.12**
Pulls nf-core/modules#12022: conditional `--chemistry`, qcatch `0.2.12`, software versions emitted via the `versions` topic (subworkflow updated accordingly).

## Testing

Validated end-to-end on the pbmc_1k_v3 dataset (`--aligner simpleaf --protocol 10XV3`): QCATCH runs with `--chemistry 10X_3p_v3`, exit 0, produces report + filtered h5ad + metrics. nf-core modules lint on qcatch: 0 failures.

## PR checklist

- [x] Updated `CHANGELOG.md` and `docs/usage.md`
- [x] `nf-core modules lint qcatch` passes
- [x] Tested on a minimal dataset