### PR TITLE
Remove empty Unreleased section from CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
 ## v4.2.0 - 2026-06-05
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v4.2.0 - 2026-06-05
+## v4.2.0 - 2026-07-03
 
 ### Features
 


### PR DESCRIPTION
## Summary

- Remove the empty `## [Unreleased]` header from `CHANGELOG.md` ahead of the 4.2.0 release
- Release notes now start directly with `## v4.2.0 - 2026-06-05`, consistent with prior scrnaseq releases and other nf-core pipelines

Addresses review comment on #558: https://github.com/nf-core/scrnaseq/pull/558#discussion_r3488537046

## Test plan

- [x] Verify `CHANGELOG.md` starts with the version heading and no empty `[Unreleased]` section remains