### PR TITLE
Fix `--input` help text to point to scrnaseq samplesheet docs

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -20,7 +20,7 @@
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.csv$",
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
-                    "help_text": "You will need to create a samplesheet with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with at least 3 columns, and a header row. See [usage docs](https://nf-co.re/scrnaseq/usage#samplesheet-input)."
+                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 3 columns, and a header row. See [usage docs](https://nf-co.re/scrnaseq/usage#samplesheet-input)."
                 },
                 "outdir": {
                     "type": "string",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -20,7 +20,7 @@
                     "mimetype": "text/csv",
                     "pattern": "^\\S+\\.csv$",
                     "description": "Path to comma-separated file containing information about the samples in the experiment.",
-                    "help_text": "You will need to create a design file with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with 4 columns, and a header row. See [usage docs](https://nf-co.re/rnaseq/usage#samplesheet-input)."
+                    "help_text": "You will need to create a samplesheet with information about the samples in your experiment before running the pipeline. Use this parameter to specify its location. It has to be a comma-separated file with at least 3 columns, and a header row. See [usage docs](https://nf-co.re/scrnaseq/usage#samplesheet-input)."
                 },
                 "outdir": {
                     "type": "string",


### PR DESCRIPTION
It seems like a long time ago, a reference to the nf-core/rnaseq docs creeped into our documentation of the `input` param. Was pointed out by a user in [this slack thread](https://nfcore.slack.com/archives/CHN5BV5DW/p1783608984580569). This PR replaces the reference with the proper one.