### PR TITLE
Bump nf schema 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Chore
 
+- Bump the `nf-schema` plugin from `2.5.1` to `2.8.0`, so that `pattern` validation of samplesheet paths on proxy filesystems (e.g. `lamin://`) is retried against the resolved real path (see [nf-schema#217](https://github.com/nextflow-io/nf-schema/issues/217); [#xxx](https://github.com/nf-core/scrnaseq/pull/xxx))
 - Remove orphaned `GFFREAD_TRANSCRIPTOME` local module (unused since simpleaf replaced Salmon index building in 2022) ([#565](https://github.com/nf-core/scrnaseq/pull/565))
 - Replace the local `GTF_GENE_FILTER` module with the shared nf-core `custom/gtffilter` module ([#465](https://github.com/nf-core/scrnaseq/issues/465))
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -355,7 +355,7 @@ manifest {
 
 // Nextflow plugins
 plugins {
-    id 'nf-schema@2.5.1' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.8.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
 }
 
 validation {


### PR DESCRIPTION
This PR bumps the `nf-schema` plugin from `2.5.1` to `2.8.0`.

The main motivation is [nf-schema#217](https://github.com/nextflow-io/nf-schema/issues/217), fixed in [2.8.0](https://github.com/nextflow-io/nf-schema/releases/tag/2.8.0). With nf-schema<2.8.0, calling `nextflow run nf-core/scrnaseq --input lamin://instance/artifacts/ABCDEFGHI` fails even though the lamin URI can correctly resolve to a csv file. With nf-schema 2.8.0, the validation of the input value is retried against the resolved real path (e.g. `s3://lamin-instance/path/to/underlying/input.csv`).

This version bump thus allows `nf-core/scrnaseq` workflows to be ran with lamin:// input artifacts.

I wasn't sure whether to send this PR to the master branch or to the dev branch. If master is better, I'm happy to recreate it there.

---

One caveat is that nf-schema 2.8.0 requires Nextflow >=26.04.0 (2.7.3 and earlier still work with 25.10.0), so this PR also bumps the pipeline's minimum Nextflow version from 25.10.4 to 26.04.0.

---

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] ~If you've fixed a bug or added code that should be tested, add tests!~
- [ ] ~If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/scrnaseq/tree/master/docs/CONTRIBUTING.md)~
- [ ] ~If necessary, also make a PR on the nf-core/scrnaseq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.~
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] ~Usage Documentation in `docs/usage.md` is updated.~
- [ ] ~Output Documentation in `docs/output.md` is updated.~
- [x] `CHANGELOG.md` is updated.
- [ ] ~`README.md` is updated (including new tool citations and authors/contributors).~
