### PR TITLE
Fix cellrangerarc alignment with a pre-built cellranger index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixes
 
 - Fix pipeline attempts to access igenomes buckets even with `--igenomes_ignore=true` [#568](https://github.com/nf-core/scrnaseq/issues/568)
+- Fix `--aligner cellrangerarc` with a pre-built `--cellranger_index`, which failed in `CELLRANGERARC_COUNT` with `Path value cannot be null` ([#576](https://github.com/nf-core/scrnaseq/issues/576))
 
 ## v4.2.0 - 2026-07-03
 

--- a/subworkflows/local/align_cellrangerarc/main.nf
+++ b/subworkflows/local/align_cellrangerarc/main.nf
@@ -20,7 +20,12 @@ workflow CELLRANGERARC_ALIGN {
         assert cellranger_index || (fasta && gtf):
             "Must provide either a cellranger index or a bundle of a fasta file ('--fasta') + gtf file ('--gtf')."
 
-        if (!cellranger_index) {
+        if (cellranger_index) {
+            // CELLRANGERARC_COUNT takes the reference as a [ meta, reference ] tuple, the
+            // same shape CELLRANGERARC_MKREF emits, so wrap the user-supplied index to match.
+            ch_reference = channel.value([ [ id: cellranger_index.name ], cellranger_index ])
+        }
+        else {
             assert (( !params.cellrangerarc_reference && !cellrangerarc_config ) ||
                     ( params.cellrangerarc_reference && cellrangerarc_config ) ) :
                 "If you provide a config file you also have to specific the reference name and vice versa."
@@ -39,13 +44,13 @@ workflow CELLRANGERARC_ALIGN {
                 }
 
             CELLRANGERARC_MKREF( ch_cellrangerarc_mkref )
-            cellranger_index = CELLRANGERARC_MKREF.out.reference
+            ch_reference = CELLRANGERARC_MKREF.out.reference
         }
 
         // Obtain read counts
         CELLRANGERARC_COUNT (
             ch_fastq,
-            cellranger_index
+            ch_reference
         )
 
         // Parse the output channels to obtain filtered and raw matrices

--- a/subworkflows/local/align_cellrangerarc/tests/main.nf.test
+++ b/subworkflows/local/align_cellrangerarc/tests/main.nf.test
@@ -1,0 +1,62 @@
+nextflow_workflow {
+
+    name "Test Workflow CELLRANGERARC_ALIGN"
+    script "../main.nf"
+    workflow "CELLRANGERARC_ALIGN"
+    tag "subworkflows"
+    tag "subworkflows_local"
+    tag "align_cellrangerarc"
+
+    test("Should build the reference when no index is given") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                input[0] = channel.value([ [ id: 'genome' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.fasta', checkIfExists: true) ])
+                input[1] = channel.value([ [ id: 'genome' ], file(params.modules_testdata_base_path + 'genomics/homo_sapiens/genome/genome.gtf', checkIfExists: true) ])
+                input[2] = []
+                input[3] = []
+                input[4] = channel.of([ [ id: 'test' ], [ 'gex', 'atac' ], [ 'test_gex', 'test_atac' ], [] ])
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+
+    test("Should accept a pre-built reference passed with --cellranger_index") {
+
+        options "-stub"
+
+        when {
+            workflow {
+                """
+                def reference = file("${outputDir}/cellrangerarc_reference")
+                reference.mkdirs()
+
+                input[0] = []
+                input[1] = []
+                input[2] = []
+                input[3] = reference
+                input[4] = channel.of([ [ id: 'test' ], [ 'gex', 'atac' ], [ 'test_gex', 'test_atac' ], [] ])
+                input[5] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert workflow.success },
+                { assert snapshot(workflow.out).match() }
+            )
+        }
+    }
+}

--- a/subworkflows/local/align_cellrangerarc/tests/main.nf.test.snap
+++ b/subworkflows/local/align_cellrangerarc/tests/main.nf.test.snap
@@ -1,0 +1,144 @@
+{
+    "Should accept a pre-built reference passed with --cellranger_index": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "fake_file.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "filtered"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "raw"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_mtx_filtered": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "filtered"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_mtx_raw": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "raw"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_out": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "fake_file.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-09-06T08:51:02.343469"
+    },
+    "Should build the reference when no index is given": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "fake_file.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "filtered"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "raw"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_mtx_filtered": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "filtered"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_mtx_raw": [
+                    [
+                        {
+                            "id": "test",
+                            "input_type": "raw"
+                        },
+                        [
+                            
+                        ]
+                    ]
+                ],
+                "cellrangerarc_out": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "fake_file.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-09-06T08:50:56.92336"
+    }
+}

--- a/subworkflows/local/align_cellrangerarc/tests/nextflow.config
+++ b/subworkflows/local/align_cellrangerarc/tests/nextflow.config
@@ -1,0 +1,7 @@
+process {
+    resourceLimits = [
+        cpus: 2,
+        memory: '6.GB',
+        time: '6.h'
+    ]
+}


### PR DESCRIPTION
Fixes #576.

`CELLRANGERARC_COUNT` takes its reference as a `[ meta, reference ]` tuple, which is the shape `CELLRANGERARC_MKREF` emits. A reference supplied with `--cellranger_index` was forwarded to the module as a bare path instead, so Nextflow bound it to `meta2` and left `reference` null — every `--aligner cellrangerarc` run with a pre-built index failed at input binding with `Path value cannot be null`, before any task was submitted. Only the mkref path (`--fasta` + `--gtf`) worked, even though `docs/usage.md` recommends supplying the index.

This wraps the supplied index in the subworkflow so both branches hand `CELLRANGERARC_COUNT` the same shape. `CELLRANGER_COUNT` declares a bare `path reference`, which is why the non-ARC aligner was unaffected; changing the ARC module's declaration to match would mean patching a shared nf-core module, so the subworkflow is fixed instead.

Also adds `subworkflows/local/align_cellrangerarc/tests/`, a stub nf-test covering both branches. The pre-built-index test fails on `dev` with exactly the reported error and passes with this change.
